### PR TITLE
feat: add CI pipeline with Lighthouse CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run format:check
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run build
+      - run: npm audit --audit-level=high
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  lighthouse:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          uploadArtifacts: true
+          configPath: ./lighthouserc.json

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,16 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "url": ["http://localhost/"]
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.95 }],
+        "categories:accessibility": ["error", { "minScore": 0.95 }],
+        "categories:best-practices": ["error", { "minScore": 0.95 }],
+        "categories:seo": ["error", { "minScore": 1.0 }]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- GitHub Actions CI workflow (push to main + all PRs)
- Pipeline: install → format → lint → typecheck → build → npm audit → Lighthouse CI
- Lighthouse thresholds: >=95 all categories, 100 SEO
- Build artifact upload for downstream jobs

## Manual Steps Required
- Connect venturecrane/vc-web to Cloudflare Pages for preview deploys
- No secrets needed for CI itself

## Test plan
- [ ] CI workflow runs on this PR
- [ ] All steps pass
- [ ] Lighthouse scores meet thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)