### PR TITLE
feat: add BaseLayout with responsive shell

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,0 +1,36 @@
+---
+import '../styles/global.css'
+
+interface Props {
+  title: string
+  description?: string
+  ogImage?: string
+}
+
+const { title, description = 'The product factory that shows its work.', ogImage } = Astro.props
+const canonicalURL = new URL(Astro.url.pathname, Astro.site)
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalURL} />
+    {ogImage && <meta property="og:image" content={ogImage} />}
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalURL} />
+    <link rel="sitemap" href="/sitemap-index.xml" />
+  </head>
+  <body class="bg-chrome text-vc-text">
+    <a href="#main-content" class="skip-link">Skip to content</a>
+    <slot name="header" />
+    <main id="main-content" class="mx-auto max-w-[var(--vc-content-width)] px-4 py-8 sm:px-6">
+      <slot />
+    </main>
+    <slot name="footer" />
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,17 +1,8 @@
 ---
-
+import Base from '../layouts/Base.astro'
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Venture Crane</title>
-  </head>
-  <body>
-    <main>
-      <h1>Venture Crane</h1>
-      <p>The product factory that shows its work.</p>
-    </main>
-  </body>
-</html>
+<Base title="Venture Crane">
+  <h1>Venture Crane</h1>
+  <p>The product factory that shows its work.</p>
+</Base>


### PR DESCRIPTION
## Summary

Closes #177

- Adds `src/layouts/Base.astro` with proper `<head>` meta (charset, viewport, title, description, canonical URL, Open Graph tags)
- Skip-to-content accessibility link
- Content wrapper: max-width 680px, centered, responsive padding
- Named slots for header and footer (ready for navigation components)
- Updates `src/pages/index.astro` to use the new layout

## Test plan

- [ ] `npm run verify` passes (typecheck, format, lint, build)
- [ ] Page renders with correct meta tags
- [ ] Skip-to-content link visible on focus
- [ ] Content centered at 680px max-width
- [ ] Responsive padding on mobile

Generated with [Claude Code](https://claude.com/claude-code)