### PR TITLE
feat: add Header, MobileNav, and Footer components

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,90 @@
+---
+const ventureLinks = [
+  { href: 'https://durganfieldguide.com', label: 'Durgan Field Guide' },
+  { href: 'https://kidexpenses.com', label: 'Kid Expenses' },
+  { href: 'https://draftcrane.com', label: 'Draft Crane' },
+  { href: 'https://siliconcrane.com', label: 'Silicon Crane' },
+]
+
+const socialLinks = [
+  { href: 'https://x.com/venturecrane', label: 'X' },
+  { href: 'https://github.com/venturecrane', label: 'GitHub' },
+]
+
+const legalLinks = [
+  { href: '/privacy/', label: 'Privacy' },
+  { href: '/terms/', label: 'Terms' },
+]
+
+const currentYear = new Date().getFullYear()
+---
+
+<footer class="border-t border-border bg-chrome">
+  <div class="mx-auto max-w-[var(--vc-content-width)] px-4 py-8 sm:px-6">
+    <div class="grid gap-8 sm:grid-cols-3">
+      <div>
+        <h3 class="mb-3 text-sm font-semibold text-vc-text">Ventures</h3>
+        <ul class="list-none space-y-2 p-0">
+          {
+            ventureLinks.map(({ href, label }) => (
+              <li>
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-sm text-vc-text-muted no-underline hover:text-vc-text"
+                >
+                  {label}
+                </a>
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+
+      <div>
+        <h3 class="mb-3 text-sm font-semibold text-vc-text">Social</h3>
+        <ul class="list-none space-y-2 p-0">
+          {
+            socialLinks.map(({ href, label }) => (
+              <li>
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-sm text-vc-text-muted no-underline hover:text-vc-text"
+                >
+                  {label}
+                </a>
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+
+      <div>
+        <h3 class="mb-3 text-sm font-semibold text-vc-text">Legal</h3>
+        <ul class="list-none space-y-2 p-0">
+          {
+            legalLinks.map(({ href, label }) => (
+              <li>
+                <a href={href} class="text-sm text-vc-text-muted no-underline hover:text-vc-text">
+                  {label}
+                </a>
+              </li>
+            ))
+          }
+          <li>
+            <a href="/feed.xml" class="text-sm text-vc-text-muted no-underline hover:text-vc-text">
+              RSS
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="mt-8 border-t border-border pt-4 text-center text-sm text-vc-text-muted">
+      &copy; {currentYear} Venture Crane. All rights reserved.
+    </div>
+  </div>
+</footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,43 @@
+---
+import MobileNav from './MobileNav.astro'
+
+const pathname = Astro.url.pathname
+
+const navLinks = [
+  { href: '/', label: 'Home' },
+  { href: '/portfolio/', label: 'Portfolio' },
+  { href: '/methodology/', label: 'Methodology' },
+  { href: '/articles/', label: 'Articles' },
+]
+---
+
+<header class="border-b border-border bg-chrome">
+  <div
+    class="mx-auto flex max-w-[var(--vc-content-width)] items-center justify-between px-4 py-4 sm:px-6"
+  >
+    <a href="/" class="text-lg font-bold text-vc-text no-underline hover:text-accent">
+      Venture Crane
+    </a>
+
+    <nav class="hidden sm:flex sm:gap-6" aria-label="Main">
+      {
+        navLinks.map(({ href, label }) => (
+          <a
+            href={href}
+            aria-current={pathname === href ? 'page' : undefined}
+            class:list={[
+              'text-sm no-underline transition-colors',
+              pathname === href
+                ? 'text-accent font-semibold'
+                : 'text-vc-text-muted hover:text-vc-text',
+            ]}
+          >
+            {label}
+          </a>
+        ))
+      }
+    </nav>
+
+    <MobileNav />
+  </div>
+</header>

--- a/src/components/MobileNav.astro
+++ b/src/components/MobileNav.astro
@@ -1,0 +1,63 @@
+---
+const pathname = Astro.url.pathname
+
+const navLinks = [
+  { href: '/', label: 'Home' },
+  { href: '/portfolio/', label: 'Portfolio' },
+  { href: '/methodology/', label: 'Methodology' },
+  { href: '/articles/', label: 'Articles' },
+]
+---
+
+<details class="mobile-nav sm:hidden">
+  <summary class="flex h-8 w-8 cursor-pointer items-center justify-center" aria-label="Menu">
+    <svg
+      class="h-6 w-6 text-vc-text"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M4 6h16M4 12h16M4 18h16"></path>
+    </svg>
+  </summary>
+  <nav
+    class="absolute left-0 right-0 border-b border-border bg-chrome px-4 py-4"
+    aria-label="Mobile"
+  >
+    {
+      navLinks.map(({ href, label }) => (
+        <a
+          href={href}
+          aria-current={pathname === href ? 'page' : undefined}
+          class:list={[
+            'block py-2 text-sm no-underline',
+            pathname === href
+              ? 'text-accent font-semibold'
+              : 'text-vc-text-muted hover:text-vc-text',
+          ]}
+        >
+          {label}
+        </a>
+      ))
+    }
+  </nav>
+</details>
+
+<style>
+  .mobile-nav {
+    position: relative;
+  }
+
+  .mobile-nav summary {
+    list-style: none;
+  }
+
+  .mobile-nav summary::-webkit-details-marker {
+    display: none;
+  }
+</style>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,5 +1,7 @@
 ---
 import '../styles/global.css'
+import Header from '../components/Header.astro'
+import Footer from '../components/Footer.astro'
 
 interface Props {
   title: string
@@ -27,10 +29,10 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
   </head>
   <body class="bg-chrome text-vc-text">
     <a href="#main-content" class="skip-link">Skip to content</a>
-    <slot name="header" />
+    <Header />
     <main id="main-content" class="mx-auto max-w-[var(--vc-content-width)] px-4 py-8 sm:px-6">
       <slot />
     </main>
-    <slot name="footer" />
+    <Footer />
   </body>
 </html>


### PR DESCRIPTION
## Summary

Closes #178

Depends on #177 (PR #2)

- **Header.astro**: Wordmark linking to /, 4 nav links with `aria-current="page"` support, responsive (hidden on mobile)
- **MobileNav.astro**: CSS-only `<details><summary>` hamburger menu, visible below 640px, zero JavaScript
- **Footer.astro**: Venture links (external, target=_blank), social links (X, GitHub), legal links (Privacy, Terms), RSS link
- **Base.astro**: Updated to import and render Header and Footer

## Test plan

- [ ] `npm run verify` passes (typecheck, format, lint, build)
- [ ] Header renders with wordmark and nav links on desktop
- [ ] Active page link highlighted with accent color
- [ ] Mobile nav opens/closes with details/summary (no JS)
- [ ] Footer renders all link sections
- [ ] External links open in new tab
- [ ] Skip-to-content link still works

Generated with [Claude Code](https://claude.com/claude-code)