### PR TITLE
feat: add portfolio page with venture cards (#189)

### DIFF
--- a/src/components/PortfolioCard.astro
+++ b/src/components/PortfolioCard.astro
@@ -1,0 +1,80 @@
+---
+import type { Venture } from '../data/ventures'
+
+interface Props {
+  venture: Venture
+}
+
+const { venture } = Astro.props
+
+const statusColors: Record<Venture['status'], string> = {
+  launched: 'bg-green-900/40 text-green-300 border-green-700/50',
+  active: 'bg-accent/10 text-accent border-accent/30',
+  'in-development': 'bg-yellow-900/40 text-yellow-300 border-yellow-700/50',
+  lab: 'bg-gray-700/40 text-gray-300 border-gray-600/50',
+}
+
+const statusLabels: Record<Venture['status'], string> = {
+  launched: 'Launched',
+  active: 'Active',
+  'in-development': 'In Development',
+  lab: 'Lab',
+}
+
+const isLive = venture.status === 'launched' || venture.status === 'active'
+---
+
+<article class="rounded-lg border border-border bg-surface p-6">
+  <div class="mb-3 flex items-start justify-between gap-3">
+    <h3 class="text-lg font-semibold text-vc-text">{venture.name}</h3>
+    <span
+      class:list={[
+        'inline-flex shrink-0 items-center rounded-full border px-2.5 py-0.5 text-xs font-medium',
+        statusColors[venture.status],
+      ]}
+    >
+      {statusLabels[venture.status]}
+    </span>
+  </div>
+
+  <p class="mb-4 text-sm text-vc-text-muted">{venture.description}</p>
+
+  <div class="flex flex-wrap gap-1.5">
+    {
+      venture.techStack.map((tech) => (
+        <span class="rounded bg-surface-raised px-2 py-0.5 text-xs text-vc-text-muted">{tech}</span>
+      ))
+    }
+  </div>
+
+  {
+    isLive && venture.url && (
+      <div class="mt-4">
+        <a
+          href={venture.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-1.5 text-sm text-accent no-underline hover:text-accent-hover"
+        >
+          Visit
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+            <polyline points="15 3 21 3 21 9" />
+            <line x1="10" y1="14" x2="21" y2="3" />
+          </svg>
+        </a>
+      </div>
+    )
+  }
+</article>

--- a/src/data/ventures.ts
+++ b/src/data/ventures.ts
@@ -1,0 +1,50 @@
+export interface Venture {
+  name: string
+  slug: string
+  description: string
+  status: 'launched' | 'active' | 'in-development' | 'lab'
+  techStack: string[]
+  url?: string
+}
+
+export const ventures: Venture[] = [
+  {
+    name: 'Durgan Field Guide',
+    slug: 'dfg',
+    description:
+      'A trail guide platform for hikers and outdoor enthusiasts. Curated trail information with detailed conditions, difficulty ratings, and seasonal recommendations.',
+    status: 'launched',
+    techStack: ['Astro', 'Cloudflare Pages', 'D1'],
+    url: 'https://durganfieldguide.com',
+  },
+  {
+    name: 'Kid Expenses',
+    slug: 'ke',
+    description:
+      'Family expense tracking built for shared custody households. Track, categorize, and split child-related expenses between co-parents.',
+    status: 'active',
+    techStack: ['Next.js', 'Cloudflare Workers', 'D1'],
+    url: 'https://kidexpenses.com',
+  },
+  {
+    name: 'Draft Crane',
+    slug: 'dc',
+    description:
+      'Content tools for AI-assisted writing workflows. Structured editing and review pipelines for technical content.',
+    status: 'in-development',
+    techStack: ['Astro', 'Cloudflare Workers'],
+  },
+  {
+    name: 'Silicon Crane',
+    slug: 'sc',
+    description:
+      'Validation lab for testing product ideas before full build commitment. Rapid prototype-to-signal pipeline.',
+    status: 'lab',
+    techStack: ['Cloudflare Workers', 'D1'],
+  },
+]
+
+const statusOrder = { launched: 0, active: 1, 'in-development': 2, lab: 3 }
+export const sortedVentures = [...ventures].sort(
+  (a, b) => statusOrder[a.status] - statusOrder[b.status]
+)

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -1,0 +1,21 @@
+---
+import Base from '../layouts/Base.astro'
+import PortfolioCard from '../components/PortfolioCard.astro'
+import { sortedVentures } from '../data/ventures'
+---
+
+<Base
+  title="Portfolio | Venture Crane"
+  description="Products built with AI agents under human direction."
+>
+  <h1 class="mb-2">Portfolio</h1>
+  <p class="mb-8 text-lg text-vc-text-muted">
+    Products built with AI agents under human direction.
+  </p>
+
+  <div class="grid gap-4">
+    {sortedVentures.map((venture) => <PortfolioCard venture={venture} />)}
+  </div>
+
+  <p class="mt-8 text-sm text-vc-text-muted">Last updated February 2026</p>
+</Base>


### PR DESCRIPTION
## Summary
- Add portfolio page at `/portfolio/` displaying all Venture Crane ventures
- Cards show name, description, status badge (launched/active/in-development/lab), and tech stack tags
- Live ventures (launched/active) include external "Visit" link; pre-launch ventures show badge only
- Ventures sorted by status: launched first, lab last
- Static venture data in `src/data/ventures.ts` for reuse on homepage

## Files Added
- `src/data/ventures.ts` — Venture interface and static data
- `src/components/PortfolioCard.astro` — Card component with status badges
- `src/pages/portfolio.astro` — Portfolio page layout

Closes #189

## Test plan
- [ ] Verify `/portfolio/` renders all 4 ventures in correct order
- [ ] Verify status badge colors match spec (green, teal, yellow, gray)
- [ ] Verify "Visit" links appear only for launched/active ventures
- [ ] Verify external links open in new tab
- [ ] Verify responsive layout on mobile

Generated with [Claude Code](https://claude.com/claude-code)