### PR TITLE
feat: add article pages with listing, detail view, and prose styles (#180)

### DIFF
--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -1,0 +1,25 @@
+---
+interface Props {
+  title: string
+  date: Date
+  description: string
+  readingTime: number
+  slug: string
+}
+
+const { title, date, description, readingTime, slug } = Astro.props
+
+const formatDate = (d: Date) =>
+  d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+---
+
+<a
+  href={`/articles/${slug}/`}
+  class="group block rounded-lg bg-surface p-6 no-underline transition-colors hover:bg-surface-raised"
+>
+  <h2 class="text-lg font-semibold text-vc-text group-hover:text-accent">{title}</h2>
+  <div class="mt-1 text-sm text-vc-text-muted">
+    {formatDate(date)} &middot; {readingTime} min read
+  </div>
+  <p class="mt-2 text-vc-text-muted">{description}</p>
+</a>

--- a/src/components/ArticleMeta.astro
+++ b/src/components/ArticleMeta.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  date: Date
+  readingTime: number
+  author: string
+  updatedDate?: Date
+}
+
+const { date, readingTime, author, updatedDate } = Astro.props
+
+const formatDate = (d: Date) =>
+  d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+---
+
+<div class="text-sm text-vc-text-muted">
+  <span>{formatDate(date)} &middot; {readingTime} min read &middot; by {author}</span>
+  {updatedDate && <div class="mt-1">Updated: {formatDate(updatedDate)}</div>}
+</div>

--- a/src/content/articles/hello-world.md
+++ b/src/content/articles/hello-world.md
@@ -4,7 +4,7 @@ date: 2026-02-14
 description: 'Placeholder article for schema validation.'
 author: 'Venture Crane'
 tags: ['placeholder']
-draft: true
+draft: false
 ---
 
 This is a placeholder article to validate the content collection schema.

--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -1,0 +1,60 @@
+---
+import Base from './Base.astro'
+import ArticleMeta from '../components/ArticleMeta.astro'
+
+interface Props {
+  title: string
+  description: string
+  date: Date
+  readingTime: number
+  author: string
+  updatedDate?: Date
+  prevArticle?: { slug: string; title: string }
+  nextArticle?: { slug: string; title: string }
+}
+
+const { title, description, date, readingTime, author, updatedDate, prevArticle, nextArticle } =
+  Astro.props
+---
+
+<Base title={`${title} — Venture Crane`} description={description}>
+  <div class="rounded-lg bg-surface p-6 sm:p-8">
+    <header class="mb-8">
+      <h1 class="mb-3">{title}</h1>
+      <ArticleMeta
+        date={date}
+        readingTime={readingTime}
+        author={author}
+        updatedDate={updatedDate}
+      />
+    </header>
+
+    <div class="vc-prose">
+      <slot />
+    </div>
+
+    {
+      (prevArticle || nextArticle) && (
+        <nav
+          class="mt-12 flex justify-between border-t border-border pt-6 text-sm"
+          aria-label="Article navigation"
+        >
+          {prevArticle ? (
+            <a href={`/articles/${prevArticle.slug}/`} class="text-accent hover:text-accent-hover">
+              &larr; {prevArticle.title}
+            </a>
+          ) : (
+            <span />
+          )}
+          {nextArticle ? (
+            <a href={`/articles/${nextArticle.slug}/`} class="text-accent hover:text-accent-hover">
+              {nextArticle.title} &rarr;
+            </a>
+          ) : (
+            <span />
+          )}
+        </nav>
+      )
+    }
+  </div>
+</Base>

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -1,0 +1,40 @@
+---
+import Article from '../../layouts/Article.astro'
+import { getCollection, render } from 'astro:content'
+
+export async function getStaticPaths() {
+  const allArticles = (await getCollection('articles'))
+    .filter((a) => !a.data.draft)
+    .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+
+  return allArticles.map((article, i) => ({
+    params: { slug: article.id },
+    props: {
+      article,
+      prevArticle: allArticles[i + 1]
+        ? { slug: allArticles[i + 1].id, title: allArticles[i + 1].data.title }
+        : undefined,
+      nextArticle: allArticles[i - 1]
+        ? { slug: allArticles[i - 1].id, title: allArticles[i - 1].data.title }
+        : undefined,
+    },
+  }))
+}
+
+const { article, prevArticle, nextArticle } = Astro.props
+const { Content } = await render(article)
+const readingTime = Math.ceil(article.body!.split(/\s+/).length / 225)
+---
+
+<Article
+  title={article.data.title}
+  description={article.data.description}
+  date={article.data.date}
+  readingTime={readingTime}
+  author={article.data.author}
+  updatedDate={article.data.updatedDate}
+  prevArticle={prevArticle}
+  nextArticle={nextArticle}
+>
+  <Content />
+</Article>

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -1,0 +1,30 @@
+---
+import Base from '../../layouts/Base.astro'
+import ArticleCard from '../../components/ArticleCard.astro'
+import { getCollection } from 'astro:content'
+
+const articles = (await getCollection('articles'))
+  .filter((a) => !a.data.draft)
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+---
+
+<Base title="Articles — Venture Crane" description="Engineering articles from Venture Crane.">
+  <h1 class="mb-8">Articles</h1>
+  {
+    articles.length > 0 ? (
+      <div class="flex flex-col gap-4">
+        {articles.map((article) => (
+          <ArticleCard
+            title={article.data.title}
+            date={article.data.date}
+            description={article.data.description}
+            readingTime={Math.ceil(article.body!.split(/\s+/).length / 225)}
+            slug={article.id}
+          />
+        ))}
+      </div>
+    ) : (
+      <p class="text-vc-text-muted">Content coming soon.</p>
+    )
+  }
+</Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -173,3 +173,89 @@ small,
   font-size: var(--vc-text-small);
   line-height: var(--vc-leading-small);
 }
+
+/* Prose content styles for rendered markdown */
+.vc-prose {
+  max-width: var(--vc-content-width);
+}
+
+.vc-prose h2 {
+  font-size: var(--vc-text-h2);
+  line-height: var(--vc-leading-h2);
+  font-weight: 600;
+  margin-top: 2em;
+  margin-bottom: 0.75em;
+}
+
+.vc-prose h3 {
+  font-size: var(--vc-text-h3);
+  line-height: var(--vc-leading-h3);
+  font-weight: 600;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+.vc-prose p {
+  margin-bottom: 1.25em;
+}
+
+.vc-prose ul,
+.vc-prose ol {
+  margin-bottom: 1.25em;
+  padding-left: 1.5em;
+}
+
+.vc-prose li {
+  margin-bottom: 0.25em;
+}
+
+.vc-prose blockquote {
+  border-left: 3px solid var(--vc-accent);
+  padding-left: 1rem;
+  margin-left: 0;
+  color: var(--vc-text-muted);
+  font-style: italic;
+}
+
+.vc-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.25em;
+  display: block;
+  overflow-x: auto;
+}
+
+.vc-prose th,
+.vc-prose td {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--vc-border);
+  text-align: left;
+}
+
+.vc-prose th {
+  font-weight: 600;
+  background-color: var(--vc-surface-raised);
+}
+
+.vc-prose img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.375rem;
+}
+
+.vc-prose code:not(pre code) {
+  background-color: var(--vc-surface-raised);
+  padding: 0.125em 0.25em;
+  border-radius: 0.25rem;
+}
+
+.vc-prose a {
+  color: var(--vc-accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.vc-prose a:hover {
+  color: var(--vc-accent-hover);
+}


### PR DESCRIPTION
## Summary
- Article.astro layout extending Base with surface background and prev/next article navigation
- ArticleMeta and ArticleCard components for consistent metadata display
- Articles index page with draft filtering, date sorting, and empty state
- Dynamic `[...slug]` page with static paths and reading time calculation
- `.vc-prose` CSS class with full markdown rendering styles (headings, lists, blockquotes, tables, code, links, images)
- Set hello-world placeholder article to non-draft for visible content

Closes #180

## Test plan
- [ ] `/articles/` shows the hello-world article card
- [ ] `/articles/hello-world/` renders article with proper layout
- [ ] ArticleMeta shows date, reading time, and author
- [ ] `.vc-prose` styles render correctly for all markdown elements
- [ ] Previous/next navigation appears when multiple articles exist
- [ ] Draft articles are excluded from listing and routing
- [ ] Build passes with no errors

Generated with [Claude Code](https://claude.com/claude-code)