### PR TITLE
feat: add build log pages (#185)

### DIFF
--- a/src/components/LogEntry.astro
+++ b/src/components/LogEntry.astro
@@ -1,0 +1,20 @@
+---
+interface Props {
+  title: string
+  date: Date
+  slug: string
+}
+
+const { title, date, slug } = Astro.props
+
+const formatDate = (d: Date) =>
+  d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+---
+
+<a
+  href={`/log/${slug}/`}
+  class="group block rounded-lg p-4 no-underline transition-colors hover:bg-surface"
+>
+  <div class="text-sm font-medium text-vc-text-muted">{formatDate(date)}</div>
+  <h2 class="mt-1 text-base font-semibold text-vc-text group-hover:text-accent">{title}</h2>
+</a>

--- a/src/content/logs/2026-02-14-initial-setup.md
+++ b/src/content/logs/2026-02-14-initial-setup.md
@@ -2,7 +2,7 @@
 title: 'Initial Setup'
 date: 2026-02-14
 tags: ['infrastructure']
-draft: true
+draft: false
 ---
 
 Placeholder build log entry for schema validation.

--- a/src/layouts/Log.astro
+++ b/src/layouts/Log.astro
@@ -1,0 +1,40 @@
+---
+import Base from './Base.astro'
+
+interface Props {
+  title: string
+  date: Date
+  tags?: string[]
+}
+
+const { title, date, tags } = Astro.props
+
+const formatDate = (d: Date) =>
+  d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+---
+
+<Base title={`${title} — Venture Crane`}>
+  <div class="rounded-lg bg-surface p-6 sm:p-8">
+    <header class="mb-8">
+      <h1 class="mb-3">{title}</h1>
+      <div class="text-sm text-vc-text-muted">
+        {formatDate(date)}
+      </div>
+      {
+        tags && tags.length > 0 && (
+          <div class="mt-2 flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <span class="rounded bg-surface-raised px-2 py-0.5 text-xs text-vc-text-muted">
+                {tag}
+              </span>
+            ))}
+          </div>
+        )
+      }
+    </header>
+
+    <div class="vc-prose">
+      <slot />
+    </div>
+  </div>
+</Base>

--- a/src/pages/log/[...slug].astro
+++ b/src/pages/log/[...slug].astro
@@ -1,0 +1,20 @@
+---
+import Log from '../../layouts/Log.astro'
+import { getCollection, render } from 'astro:content'
+
+export async function getStaticPaths() {
+  const allLogs = (await getCollection('logs')).filter((l) => !l.data.draft)
+
+  return allLogs.map((log) => ({
+    params: { slug: log.id },
+    props: { log },
+  }))
+}
+
+const { log } = Astro.props
+const { Content } = await render(log)
+---
+
+<Log title={log.data.title} date={log.data.date} tags={log.data.tags}>
+  <Content />
+</Log>

--- a/src/pages/log/index.astro
+++ b/src/pages/log/index.astro
@@ -1,0 +1,27 @@
+---
+import Base from '../../layouts/Base.astro'
+import LogEntry from '../../components/LogEntry.astro'
+import { getCollection } from 'astro:content'
+
+const logs = (await getCollection('logs'))
+  .filter((l) => !l.data.draft)
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+---
+
+<Base
+  title="Build Log — Venture Crane"
+  description="Build log from the Venture Crane product factory."
+>
+  <h1 class="mb-8">Build Log</h1>
+  {
+    logs.length > 0 ? (
+      <div class="flex flex-col gap-2">
+        {logs.map((log) => (
+          <LogEntry title={log.data.title} date={log.data.date} slug={log.id} />
+        ))}
+      </div>
+    ) : (
+      <p class="text-vc-text-muted">No build log entries yet.</p>
+    )
+  }
+</Base>


### PR DESCRIPTION
## Summary
- Add `Log.astro` layout with date-prominent header and tag display
- Add `LogEntry.astro` component for log listing with lighter visual treatment
- Add log index page (`/log/`) with draft filtering and date-desc sorting
- Add dynamic log detail page (`/log/[...slug]/`)
- Update placeholder log entry to non-draft

Closes #185

## Test plan
- [ ] Verify `/log/` renders the log index with the initial setup entry
- [ ] Verify `/log/2026-02-14-initial-setup/` renders the log detail page
- [ ] Verify tags display on the detail page
- [ ] Verify empty state shows when all logs are drafts

Generated with [Claude Code](https://claude.com/claude-code)