### PR TITLE
feat: add WordPress redirects for Cloudflare Pages (#184)

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,25 @@
+# WordPress admin and system URLs
+/wp-admin/*  /  301
+/wp-login.php  /  301
+/wp-content/*  /  301
+/wp-includes/*  /  301
+/xmlrpc.php  /  301
+
+# WordPress feed to new RSS
+/feed/  /feed.xml  301
+/feed  /feed.xml  301
+/rss/  /feed.xml  301
+/rss  /feed.xml  301
+
+# Common WordPress page slugs (map to equivalents)
+/about/  /methodology/  301
+/about  /methodology/  301
+/blog/  /articles/  301
+/blog  /articles/  301
+
+# WordPress pagination
+/page/*  /  301
+
+# WordPress category/tag archives
+/category/*  /articles/  301
+/tag/*  /articles/  301


### PR DESCRIPTION
## Summary
- Adds `public/_redirects` file for Cloudflare Pages
- Redirects WordPress admin URLs (wp-admin, wp-login, xmlrpc) to root
- Maps old WordPress feeds (/feed/, /rss/) to /feed.xml
- Redirects WordPress slugs (/about -> /methodology/, /blog -> /articles/)
- Handles WordPress pagination, category, and tag archive URLs

Closes #184

## Test plan
- [ ] Verify `_redirects` file is present in `dist/` after build
- [ ] Deploy to Cloudflare Pages preview and test redirect URLs
- [ ] Confirm 301 status codes in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)