### PR TITLE
feat: configure Shiki syntax highlighting with github-dark (#181)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,11 @@ import sitemap from '@astrojs/sitemap'
 export default defineConfig({
   site: 'https://venturecrane.com',
   output: 'static',
+  markdown: {
+    shikiConfig: {
+      theme: 'github-dark',
+    },
+  },
   vite: {
     plugins: [tailwindcss()],
   },


### PR DESCRIPTION
## Summary
- Configure Shiki syntax highlighting in astro.config.mjs with `github-dark` theme
- Good contrast against the dark code block background (`--vc-code-bg: #14142a`)
- Shiki is built into Astro 5, no additional dependencies needed

Closes #181

## Test plan
- [ ] Code blocks in markdown articles render with syntax highlighting
- [ ] `github-dark` theme colors have good contrast on dark backgrounds
- [ ] Build passes with no errors

Generated with [Claude Code](https://claude.com/claude-code)