### PR TITLE
feat: add RSS feed with articles and build logs (#191)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.0",
         "@astrojs/cloudflare": "^12.0.0",
+        "@astrojs/rss": "^4.0.15",
         "@astrojs/sitemap": "^3.3.0",
         "astro": "^5.17.0",
         "typescript": "^5.3.0"
@@ -687,6 +688,16 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.15.tgz",
+      "integrity": "sha512-uXO/k6AhRkIDXmRoc6xQpoPZrimQNUmS43X4+60yunfuMNHtSRN5e/FiSi7NApcZqmugSMc5+cJi8ovqgO+qIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.3.3",
+        "piccolore": "^0.1.3"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -3566,6 +3577,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.17.2.tgz",
       "integrity": "sha512-7jnMqGo53hOQNwo1N/wqeOvUp8wwW/p+DeerSjSkHNx8L/1mhy6P7rVo7EhdmF8DpKqw0tl/B5Fx1WcIzg1ysA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -5484,6 +5496,24 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -8924,7 +8954,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9308,6 +9337,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/suf-log": {
       "version": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.0",
     "@astrojs/cloudflare": "^12.0.0",
+    "@astrojs/rss": "^4.0.15",
     "@astrojs/sitemap": "^3.3.0",
     "astro": "^5.17.0",
     "typescript": "^5.3.0"

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -1,0 +1,30 @@
+import rss from '@astrojs/rss'
+import type { APIContext } from 'astro'
+import { getCollection } from 'astro:content'
+
+export async function GET(context: APIContext) {
+  const articles = await getCollection('articles', ({ data }) => !data.draft)
+  const logs = await getCollection('logs', ({ data }) => !data.draft)
+
+  const allItems = [
+    ...articles.map((article) => ({
+      title: article.data.title,
+      pubDate: article.data.date,
+      description: article.data.description || '',
+      link: `/articles/${article.id}/`,
+    })),
+    ...logs.map((log) => ({
+      title: log.data.title,
+      pubDate: log.data.date,
+      description: '',
+      link: `/log/${log.id}/`,
+    })),
+  ].sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())
+
+  return rss({
+    title: 'Venture Crane',
+    description: 'The product factory that shows its work.',
+    site: context.site!,
+    items: allItems,
+  })
+}


### PR DESCRIPTION
## Summary
- Adds `@astrojs/rss` dependency
- Creates `/feed.xml` endpoint combining articles and build log collections
- Sorts all items by date descending
- Filters out draft content

Closes #191

## Test plan
- [ ] Verify `/feed.xml` generates valid RSS XML after build
- [ ] Subscribe to feed in an RSS reader and verify entries appear
- [ ] Confirm draft articles/logs are excluded from the feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)