### PR TITLE
feat: add legal pages (#193)

### DIFF
--- a/src/content/pages/privacy.md
+++ b/src/content/pages/privacy.md
@@ -1,0 +1,24 @@
+---
+title: 'Privacy Policy'
+updatedDate: 2026-02-14
+---
+
+## Analytics
+
+This site uses Cloudflare Web Analytics, a privacy-friendly analytics service that does not use cookies, does not collect personal data, and does not track users across sites.
+
+## Data Collection
+
+This site does not collect, store, or process any personal information. There are no user accounts, no forms, no email subscriptions, and no cookies.
+
+## Third-Party Services
+
+This site is hosted on Cloudflare Pages. Cloudflare may collect standard web server logs (IP addresses, request timestamps) as part of its CDN service. See [Cloudflare's privacy policy](https://www.cloudflare.com/privacypolicy/) for details.
+
+## Contact
+
+Questions about this privacy policy can be directed to the Venture Crane team via [GitHub](https://github.com/venturecrane).
+
+## Changes
+
+This policy may be updated. The "last updated" date at the top of this page reflects the most recent revision.

--- a/src/content/pages/terms.md
+++ b/src/content/pages/terms.md
@@ -1,0 +1,24 @@
+---
+title: 'Terms of Use'
+updatedDate: 2026-02-14
+---
+
+## Content
+
+All written content on this site is the property of Venture Crane (SMDurgan, LLC) unless otherwise noted. Content may be shared with attribution and a link to the original article.
+
+## Code
+
+Code snippets published in articles and build logs are provided as-is for educational purposes. Unless otherwise stated, code snippets are available under the MIT License.
+
+## Disclaimer
+
+Content on this site reflects the experiences and opinions of the author. It is provided for informational purposes only and does not constitute professional advice. Use any information, techniques, or code at your own risk.
+
+## External Links
+
+This site links to external websites and products. Venture Crane is not responsible for the content or practices of external sites.
+
+## Changes
+
+These terms may be updated. The "last updated" date reflects the most recent revision.

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,27 @@
+---
+import Base from '../layouts/Base.astro'
+import { getEntry, render } from 'astro:content'
+
+const page = await getEntry('pages', 'privacy')
+if (!page) throw new Error('Missing privacy.md in pages collection')
+const { Content } = await render(page)
+
+const formatDate = (d: Date) =>
+  d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+---
+
+<Base title="Privacy Policy — Venture Crane">
+  <div class="rounded-lg bg-surface p-6 sm:p-8">
+    <div class="vc-prose">
+      <Content />
+    </div>
+
+    {
+      page.data.updatedDate && (
+        <div class="mt-8 text-sm text-vc-text-muted">
+          Last updated: {formatDate(page.data.updatedDate)}
+        </div>
+      )
+    }
+  </div>
+</Base>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,0 +1,27 @@
+---
+import Base from '../layouts/Base.astro'
+import { getEntry, render } from 'astro:content'
+
+const page = await getEntry('pages', 'terms')
+if (!page) throw new Error('Missing terms.md in pages collection')
+const { Content } = await render(page)
+
+const formatDate = (d: Date) =>
+  d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+---
+
+<Base title="Terms of Use — Venture Crane">
+  <div class="rounded-lg bg-surface p-6 sm:p-8">
+    <div class="vc-prose">
+      <Content />
+    </div>
+
+    {
+      page.data.updatedDate && (
+        <div class="mt-8 text-sm text-vc-text-muted">
+          Last updated: {formatDate(page.data.updatedDate)}
+        </div>
+      )
+    }
+  </div>
+</Base>


### PR DESCRIPTION
## Summary
- Add privacy policy page (`/privacy/`) with Cloudflare Web Analytics and data collection info
- Add terms of use page (`/terms/`) with content licensing, code licensing, and disclaimer
- Both pages use surface background with vc-prose styling and "last updated" date
- Content pages stored as markdown in the pages collection

Closes #193

## Test plan
- [ ] Verify `/privacy/` renders the privacy policy content
- [ ] Verify `/terms/` renders the terms of use content
- [ ] Verify "last updated" dates display on both pages
- [ ] Verify footer links to `/privacy/` and `/terms/` resolve correctly

Generated with [Claude Code](https://claude.com/claude-code)