### PR TITLE
feat: build homepage with hero, portfolio, articles, and log (#188)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,86 @@
 ---
 import Base from '../layouts/Base.astro'
+import PortfolioCard from '../components/PortfolioCard.astro'
+import ArticleCard from '../components/ArticleCard.astro'
+import LogEntry from '../components/LogEntry.astro'
+import { sortedVentures } from '../data/ventures'
+import { getCollection } from 'astro:content'
+
+const articles = (await getCollection('articles'))
+  .filter((a) => !a.data.draft)
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  .slice(0, 5)
+
+const logs = (await getCollection('logs'))
+  .filter((l) => !l.data.draft)
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  .slice(0, 3)
 ---
 
 <Base title="Venture Crane">
-  <h1>Venture Crane</h1>
-  <p>The product factory that shows its work.</p>
+  <section class="py-16 text-center sm:py-24">
+    <h1 class="mb-4 text-3xl font-bold sm:text-4xl">The product factory that shows its work.</h1>
+    <p class="mx-auto max-w-lg text-lg text-vc-text-muted">
+      One person and a team of AI agents building real software products — and publishing the
+      operational reality of how it works.
+    </p>
+  </section>
+
+  <section class="mb-16">
+    <div class="mb-6 flex items-baseline justify-between">
+      <h2 class="text-xl font-semibold">Portfolio</h2>
+      <a href="/portfolio/" class="text-sm text-vc-text-muted no-underline hover:text-accent">
+        View all
+      </a>
+    </div>
+    <div class="grid gap-4">
+      {sortedVentures.map((venture) => <PortfolioCard venture={venture} />)}
+    </div>
+  </section>
+
+  <section class="mb-16">
+    <div class="mb-6 flex items-baseline justify-between">
+      <h2 class="text-xl font-semibold">Recent Articles</h2>
+      <a href="/articles/" class="text-sm text-vc-text-muted no-underline hover:text-accent">
+        View all
+      </a>
+    </div>
+    {
+      articles.length > 0 ? (
+        <div class="flex flex-col gap-4">
+          {articles.map((article) => (
+            <ArticleCard
+              title={article.data.title}
+              date={article.data.date}
+              description={article.data.description}
+              readingTime={Math.ceil(article.body!.split(/\s+/).length / 225)}
+              slug={article.id}
+            />
+          ))}
+        </div>
+      ) : (
+        <p class="text-vc-text-muted">Articles coming soon.</p>
+      )
+    }
+  </section>
+
+  <section class="mb-16">
+    <div class="mb-6 flex items-baseline justify-between">
+      <h2 class="text-xl font-semibold">Build Log</h2>
+      <a href="/log/" class="text-sm text-vc-text-muted no-underline hover:text-accent">
+        View all
+      </a>
+    </div>
+    {
+      logs.length > 0 ? (
+        <div class="flex flex-col gap-2">
+          {logs.map((log) => (
+            <LogEntry title={log.data.title} date={log.data.date} slug={log.id} />
+          ))}
+        </div>
+      ) : (
+        <p class="text-vc-text-muted">Build log entries coming soon.</p>
+      )
+    }
+  </section>
 </Base>


### PR DESCRIPTION
## Summary
- Replace placeholder homepage with full landing page
- Hero section with tagline: "The product factory that shows its work."
- Portfolio section showing all ventures via PortfolioCard component with "View all" link to /portfolio/
- Recent Articles section showing up to 5 non-draft articles with reading time, linking to /articles/
- Build Log section showing up to 3 non-draft log entries, linking to /log/
- Graceful empty states for articles and logs when no content exists
- Chrome background throughout (no stock photos, testimonials, pricing, or signup forms per BR-002)

## Files Changed
- `src/pages/index.astro` — Full homepage with hero, portfolio, articles, and build log sections

## Test plan
- [ ] Verify hero section renders with correct tagline and description
- [ ] Verify all 4 portfolio cards render in status order (launched > active > in-dev > lab)
- [ ] Verify "View all" links navigate to /portfolio/, /articles/, and /log/
- [ ] Verify articles section shows non-draft articles sorted by date descending
- [ ] Verify build log section shows non-draft logs sorted by date descending
- [ ] Verify empty states render correctly when no content exists
- [ ] Verify responsive layout on mobile
- [ ] Verify chrome background throughout (not surface)

Closes #188

Generated with [Claude Code](https://claude.com/claude-code)