### PR TITLE
feat: surface enterprise rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,19 @@ This file provides guidance for Claude Code agents working in this repository.
 
 Venture Crane marketing website (venturecrane.com). Static site built with Astro 5, Tailwind CSS, deployed to Cloudflare Pages. Zero JavaScript. Dark theme.
 
+## Session Start
+
+This repo does not currently have Crane MCP integration. Enterprise rules apply manually. See crane-console for the full module system.
+
+## Enterprise Rules
+
+- **All changes through PRs.** Never push directly to main. Branch, PR, CI, QA, merge.
+- **Never echo secret values.** Transcripts persist in ~/.claude/ and are sent to API providers. Pipe from Infisical, never inline.
+- **Verify secret VALUES, not just key existence.** Agents have stored descriptions as values before.
+- **Never auto-save to VCMS** without explicit Captain approval.
+- **Scope discipline.** Discover additional work mid-task - finish current scope, file a new issue.
+- **Escalation triggers.** Credential not found in 2 min, same error 3 times, blocked >30 min - stop and escalate.
+
 ## Build Commands
 
 ```bash


### PR DESCRIPTION
## Summary

- Add Enterprise Rules section with 6 critical guardrails (PR workflow, secrets handling, VCMS, scope discipline, escalation triggers)
- Add session start note explaining this repo lacks MCP integration

No Instruction Modules section added - vc-web needs Crane MCP integration first (tracked separately).

Part of a cross-venture initiative to surface VCMS enterprise rules directly in agent instruction files.

## Test plan

- [ ] Verify Enterprise Rules section visible in CLAUDE.md
- [ ] Verify no `crane_doc()` references (no MCP here yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)