### PR TITLE
feat: add Crane MCP integration with commands and session start

### DIFF
--- a/.claude/commands/build-log.md
+++ b/.claude/commands/build-log.md
@@ -1,0 +1,154 @@
+# /build-log - Draft a Build Log Entry
+
+Draft a short operational update (200-1,000 words) about what shipped, broke, or changed. The founder provides a topic and the agent drafts around it.
+
+## Usage
+
+```
+/build-log "Shipped the new webhook classifier and decommissioned the old monolith"
+/build-log --weekly          # synthesize from last 7 days of handoffs/git
+/build-log --weekly --days 14  # custom lookback window
+```
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- If it starts with `--weekly`, enter **weekly mode**. Check for `--days N` to set the lookback window (default: 7 days).
+- Otherwise, treat the entire argument string as the **topic**. Strip surrounding quotes if present.
+- If `$ARGUMENTS` is empty, stop: "Provide a topic: `/build-log \"what happened\"`"
+
+## Pre-flight
+
+1. **Terminology doc**: Read `~/dev/vc-web/docs/content/terminology.md`. If missing, stop: "Terminology doc not found."
+2. **Venture registry**: Read `~/dev/crane-console/config/ventures.json`. If missing, stop: "Venture registry not found."
+3. **Recent logs**: Read up to 3 most recent files in `~/dev/vc-web/src/content/logs/` for voice consistency.
+
+Store the terminology doc as `TERMINOLOGY_DOC` and the venture registry as `VENTURE_REGISTRY`.
+
+Build a list of **stealth ventures** - any venture where `portfolio.showInPortfolio` is `false`. These must not appear in the draft by name, code, or description.
+
+---
+
+## Topic Mode (default)
+
+When the founder provides a topic string:
+
+### 1. Gather lightweight context
+
+- Read the most recent handoff via `crane_context` MCP tool for the current venture (if available)
+- The 3 recent logs from pre-flight are sufficient for voice matching
+
+### 2. Draft the entry
+
+Write a 200-1,000 word build log entry following these rules:
+
+**Structure**: Flexible. No mandatory headings. The content dictates the structure. Common patterns from existing logs include "What We Did" / "What Surprised Us" sections, but these are not required. If nothing genuinely surprising happened, do not manufacture a surprise.
+
+**Voice**: First-person plural ("we") by default. Match the tone of recent logs - operational, direct, honest.
+
+**Genericization** (from terminology doc, Published Content section):
+
+- Replace `crane-*` internal names with functional descriptions (crane-context -> "the context API", crane-mcp -> "the MCP server", etc.)
+- Replace venture codes with generic codes (vc -> alpha, ke -> beta, etc.)
+- Replace "venturecrane" org references with omission or "example-org"
+- Replace specific venture counts with "multiple ventures" or "several projects"
+- Exception: "Venture Crane" in prose is fine (it's the company name on the published site)
+- Exception: External tool names are real (Claude Code, D1, Infisical, Tailscale, etc.)
+
+**Venture names** (three-tier system from terminology doc):
+
+- If the topic is about a specific public venture, use the real venture name in prose and tag the log with the venture-name tag (e.g., `kid-expenses`). The real name adds credibility and connects to the portfolio.
+- If the topic is NOT about a specific venture, genericize public venture names as before ("Project Alpha", etc.) or use "another project" / "a different venture".
+
+**Stealth filtering**: Ventures with `showInPortfolio: false` in the registry must not appear at all - not even in genericized form. If the topic involves a stealth venture, draft around it or stop and tell the Captain: "This topic involves a stealth venture. Revise the topic or confirm you want to proceed."
+
+**Style rules** (from terminology doc):
+
+- No em dashes (use hyphens)
+- No marketing language
+- No throat-clearing openers
+- Real numbers, real tool names, real configs
+- Include setbacks or honest limitations when they exist - but only when they actually exist
+
+### 3. Present and save
+
+Display the draft to the Captain. Ask:
+
+```
+Save as draft? (y/n)
+```
+
+If yes:
+
+1. Generate a slug from the title (lowercase, hyphens, no special chars)
+2. Write to `~/dev/vc-web/src/content/logs/YYYY-MM-DD-slug.md` with today's date
+3. Frontmatter: `title`, `date` (today), `tags` (infer 1-3 from content; if the log is about a specific public venture, include the venture-name tag, e.g., `kid-expenses`), `draft: true`
+4. Report: "Saved draft to {path}. Run `/edit-log {path}` before publishing."
+
+---
+
+## Weekly Mode (`--weekly`)
+
+When invoked with `--weekly`:
+
+### 1. Gather signals across all ventures
+
+For each venture in the registry:
+
+**Handoffs** (primary signal):
+
+```bash
+# Query crane-context for recent handoffs per venture
+```
+
+Use the `crane_context` MCP tool if available, or `crane_notes` to search for recent handoff-tagged notes.
+
+**Git activity** (supporting signal):
+
+```bash
+# Commits in the lookback window
+git log --oneline --since="{N} days ago" --all
+
+# Merged PRs
+gh pr list --state merged --json title,mergedAt --jq '.[] | select(.mergedAt >= "'$(date -v-{N}d +%Y-%m-%d)'")'
+
+# Closed issues
+gh issue list --state closed --json title,closedAt --jq '.[] | select(.closedAt >= "'$(date -v-{N}d +%Y-%m-%d)'")'
+```
+
+**VCMS notes** (supplementary):
+Use `crane_notes` to search for recent notes across ventures.
+
+### 2. Weight and filter
+
+- Handoff summaries carry the most weight. They contain narrative context.
+- Git metadata (commit messages, PR titles) is supporting evidence, not primary material. Do not construct narrative from commit messages alone.
+- If a venture has no handoffs in the lookback period, note it contributed no narrative signal. Do not scrape commits for padding.
+
+### 3. Quality gate
+
+Evaluate the gathered material. If it contains **no genuine setback, surprise, or non-trivial decision**, output:
+
+```
+INSUFFICIENT MATERIAL - The last {N} days produced no narrative-worthy signal. Handoff coverage was sparse and commit messages don't carry enough context for a quality log. Try /build-log "topic" with a specific topic instead.
+```
+
+Stop. Do not draft.
+
+### 4. Draft
+
+If the quality gate passes, draft using the same rules as topic mode (genericization, stealth filtering, style rules, 200-1,000 words).
+
+### 5. Present and save
+
+Same as topic mode step 3.
+
+---
+
+## Notes
+
+- **Topic mode is the 80% case.** The founder knows what happened. The bottleneck is drafting, not signal gathering.
+- **Weekly mode is fragile.** It depends on `/eod` handoffs existing. Sparse handoffs plus raw commit messages produce mediocre drafts. The quality gate prevents publishing low-quality filler.
+- **All logs save as `draft: true`.** Publishing requires `/edit-log` review and Captain approval.
+- **Stealth ventures are never exposed.** The registry's `showInPortfolio` field is the source of truth.

--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,0 +1,560 @@
+# /code-review - Codebase Review
+
+Deep codebase review with multi-model perspectives. Produces a graded scorecard stored in VCMS and a full report committed to the repo.
+
+## Arguments
+
+```
+/code-review [focus] [--quick]
+```
+
+- `focus` - Optional path to scope the review (e.g., `workers/ke-api`, `app/src/components`). If omitted, reviews the entire codebase.
+- `--quick` - Claude-only review. Skips Codex and Gemini. Faster and cheaper for routine reviews.
+
+Parse `$ARGUMENTS`:
+
+- If it contains `--quick`, set `QUICK_MODE = true` and strip the flag.
+- Whatever remains (trimmed) is `FOCUS_PATH`. Empty string means full codebase.
+
+## Execution
+
+### Step 1: Detect Context
+
+Identify the venture from cwd and `config/ventures.json`:
+
+1. Determine REPO_ROOT: walk up from cwd until `.git` is found.
+2. Derive repo name from REPO_ROOT directory name (e.g., `ke-console` -> `ke`).
+3. Read `config/ventures.json` (from crane-console at `~/dev/crane-console/config/ventures.json` if not in crane-console itself).
+4. Match venture code. Extract: `VENTURE_CODE`, `VENTURE_NAME`, `ORG`.
+5. Determine Golden Path tier from `docs/standards/golden-path.md` compliance dashboard. Default to Tier 1 if not listed.
+
+If venture cannot be determined, warn and ask the user to confirm before proceeding.
+
+Display:
+
+```
+Codebase Review: {VENTURE_NAME} ({VENTURE_CODE})
+Repo: {ORG}/{repo-name}
+Focus: {FOCUS_PATH or "Full codebase"}
+Mode: {QUICK_MODE ? "Quick (Claude-only)" : "Full (multi-model)"}
+```
+
+### Step 2: Build File Manifest
+
+Scan the codebase (or `FOCUS_PATH` if set) to build a manifest:
+
+1. Use Glob to count files by extension (`.ts`, `.tsx`, `.js`, `.json`, `.md`, `.yml`, `.sh`, etc.)
+2. Estimate total line count using `wc -l` via Bash on matched files.
+3. Identify key files: `package.json`, `tsconfig.json`, `wrangler.toml`, `CLAUDE.md`, `README.md`, `.eslintrc.*`, `.prettierrc.*`, CI workflows.
+4. If full codebase exceeds 50K lines, note it: "Large codebase ({N} lines). Review will prioritize key files and patterns."
+
+Store manifest as `FILE_MANIFEST` for use by review agents.
+
+### Step 3: Claude Review
+
+**Phase 1 (current):** A single Claude Task agent (`subagent_type: general-purpose`) works through all 7 review dimensions sequentially.
+
+**Phase 2 (future):** Split into 3 parallel agents:
+
+- **Architect** - Architecture + Code Quality
+- **Security Analyst** - Security + Testing
+- **Standards Auditor** - Dependencies + Documentation + Golden Path
+
+For Phase 1, launch one Task agent with this prompt:
+
+```
+You are performing a deep codebase review for {VENTURE_NAME} ({VENTURE_CODE}).
+
+## Codebase Context
+
+Repository: {ORG}/{REPO_NAME}
+Focus: {FOCUS_PATH or "Full codebase"}
+Golden Path Tier: {TIER}
+
+## File Manifest
+
+{FILE_MANIFEST}
+
+## Instructions
+
+Review the codebase across all 7 dimensions listed below. For each dimension:
+
+1. Read the relevant source files using the Read, Glob, and Grep tools.
+2. Identify specific findings with file paths and line numbers where possible.
+3. Classify each finding by severity: critical, high, medium, low.
+4. Provide a concrete recommendation for each finding.
+
+## Review Dimensions
+
+### 1. Architecture
+- File organization and directory structure
+- Separation of concerns (routes vs services vs types vs utils)
+- Domain boundaries and module coupling
+- Monolith risk (files > 500 lines, god objects)
+- API surface design
+
+### 2. Security
+- Authentication and authorization middleware
+- Injection vulnerabilities (SQL, XSS, command injection)
+- CORS configuration
+- Secrets handling (no hardcoded secrets, proper env var usage)
+- Rate limiting and input validation
+- Sensitive data exposure in logs or responses
+
+### 3. Code Quality
+- TypeScript strictness (strict mode, no any abuse, proper typing)
+- Error handling patterns (consistent, informative, no swallowed errors)
+- Naming conventions (consistent casing, descriptive names)
+- DRY violations (copy-pasted logic, duplicated patterns)
+- Dead code and unused imports
+
+### 4. Testing
+- Test framework presence and configuration
+- Coverage gaps (untested critical paths)
+- Test quality (meaningful assertions, not just smoke tests)
+- Mock patterns (proper isolation, not over-mocking)
+- Integration vs unit test balance
+
+### 5. Dependencies
+- Run `npm audit` via Bash (if package.json exists) and report vulnerabilities
+- Check for outdated major versions of key packages (typescript, hono, wrangler, eslint, prettier)
+- Identify unused dependencies (declared but not imported)
+- Evaluate dependency count relative to project complexity
+
+### 6. Documentation
+- CLAUDE.md completeness (commands, build instructions, architecture notes)
+- README.md quality (setup instructions, purpose, tech stack)
+- API documentation (endpoints, request/response formats)
+- Inline comments on complex logic (not obvious code)
+- Schema/database documentation
+
+### 7. Golden Path Compliance
+Review against Tier {TIER} requirements from the Golden Path standard:
+- Tier 1: Source control, CLAUDE.md, TypeScript + ESLint, no hardcoded secrets
+- Tier 2 (if applicable): Error monitoring, full CI/CD, branch protection, uptime monitoring, API docs
+- Tier 3 (if applicable): Security audit, performance baseline, full documentation, compliance review
+
+## Output Format
+
+For each dimension, output:
+
+### {N}. {Dimension Name}
+
+**Findings:**
+1. [{SEVERITY}] {FILE:LINE} - {Description}. Recommendation: {Fix}.
+2. ...
+
+**Summary:** {1-2 sentence assessment of this dimension}
+
+After all 7 dimensions, output:
+
+### Overall Assessment
+{2-3 sentences summarizing the codebase health, biggest risks, and top priorities}
+```
+
+Wait for the agent to complete. Store its output as `CLAUDE_REVIEW`.
+
+### Step 4: Codex Review (Phase 2, unless --quick)
+
+Skip this step entirely if `QUICK_MODE` is true.
+
+**Phase 1:** Skip this step. Display: "Codex review: skipped (Phase 1 - Claude-only)"
+
+**Phase 2 implementation (when enabled):**
+
+Run via Bash with a 5-minute timeout:
+
+```bash
+cd {REPO_ROOT} && codex exec \
+  "You are reviewing this codebase. For each finding, output exactly: SEVERITY|FILE:LINE|DESCRIPTION|RECOMMENDATION (one per line). Severity is critical/high/medium/low. Review for: security vulnerabilities, architectural problems, code quality issues, test gaps. Focus: {FOCUS_PATH or 'entire codebase'}. Output only findings, no preamble." \
+  -c 'sandbox_permissions=["disk-full-read-access"]' \
+  2>&1 | tee /tmp/codex-review-{VENTURE_CODE}.txt
+```
+
+- Timeout: 300000ms (5 minutes)
+- If the command fails (timeout, missing CLI, auth error), log the failure and continue: "Codex review: skipped ({reason})"
+- If it succeeds, parse the pipe-delimited output into structured findings. Store as `CODEX_REVIEW`.
+
+### Step 5: Gemini Structural Analysis (Phase 2, unless --quick)
+
+Skip this step entirely if `QUICK_MODE` is true.
+
+**Phase 1:** Skip this step. Display: "Gemini review: skipped (Phase 1 - Claude-only)"
+
+**Phase 2 implementation (when enabled):**
+
+1. Extract key source files into a digest (target ~30K tokens). Prioritize: entry points, route handlers, middleware, types, config files. Write digest to `/tmp/gemini-request-{VENTURE_CODE}.json`.
+
+2. Build the Gemini API request with structured JSON output schema (reference pattern from `workers/crane-classifier/src/index.ts:410-445`):
+
+```json
+{
+  "contents": [
+    {
+      "role": "user",
+      "parts": [{ "text": "{CODE_DIGEST}" }]
+    }
+  ],
+  "systemInstruction": {
+    "parts": [
+      {
+        "text": "You are a code reviewer focused on cross-file pattern consistency. Review for: naming convention violations, API surface inconsistencies, error handling mismatches across files, type safety gaps, and structural anti-patterns. Output findings as JSON."
+      }
+    ]
+  },
+  "generationConfig": {
+    "temperature": 0.1,
+    "responseMimeType": "application/json",
+    "responseSchema": {
+      "type": "OBJECT",
+      "properties": {
+        "findings": {
+          "type": "ARRAY",
+          "items": {
+            "type": "OBJECT",
+            "properties": {
+              "severity": { "type": "STRING", "enum": ["critical", "high", "medium", "low"] },
+              "file": { "type": "STRING" },
+              "description": { "type": "STRING" },
+              "recommendation": { "type": "STRING" }
+            },
+            "required": ["severity", "description", "recommendation"]
+          }
+        }
+      },
+      "required": ["findings"]
+    }
+  }
+}
+```
+
+3. Invoke via Bash:
+
+```bash
+GEMINI_KEY=$(printenv GEMINI_API_KEY)
+curl -s -X POST \
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent" \
+  -H "Content-Type: application/json" \
+  -H "x-goog-api-key: $GEMINI_KEY" \
+  -d @/tmp/gemini-request-{VENTURE_CODE}.json \
+  > /tmp/gemini-response-{VENTURE_CODE}.json
+```
+
+- Timeout: 30000ms (30 seconds)
+- Parse the response JSON. Extract findings from `candidates[0].content.parts[0].text`.
+- If the call fails, log and continue: "Gemini review: skipped ({reason})"
+- Store as `GEMINI_REVIEW`.
+
+### Step 6: Synthesize
+
+The orchestrator (you, not the review agents) owns final grading. This ensures single-point consistency.
+
+**6a. Deduplicate findings across models:**
+
+If multiple model outputs exist, merge findings:
+
+- Group by file and description similarity.
+- If 2+ models flagged the same issue, note convergence: "Flagged by 2/3 models" or "Flagged by 3/3 models". Convergence increases confidence.
+- Preserve unique findings from each model.
+
+**6b. Apply grading rubric:**
+
+Grade each of the 7 dimensions using the rubric below. The grade is based on the worst finding in that dimension, adjusted by count.
+
+**6c. Compare against previous review:**
+
+Search VCMS for the most recent `code-review` scorecard for this venture:
+
+```
+crane_notes tag="code-review" venture="{VENTURE_CODE}" limit=1
+```
+
+If a previous scorecard exists:
+
+- Compare dimension grades. Note improvements and regressions.
+- Calculate trend: improved, stable, or regressed.
+- If the previous review created GitHub issues (label: `source:code-review`), query their status:
+  ```bash
+  gh issue list --repo {ORG}/{REPO_NAME} --label "source:code-review" --state all --json number,title,state
+  ```
+  Report: "{N} of {M} previous findings resolved."
+
+**6d. Assign overall grade:**
+
+The overall grade is the mode of dimension grades, pulled toward the worst grade if any dimension is D or F.
+
+### Step 7: Store Artifacts
+
+**7a. VCMS Scorecard**
+
+Store a concise scorecard (under 500 words) in VCMS using `crane_note`:
+
+- Action: `create`
+- Tags: `["code-review"]`
+- Venture: `{VENTURE_CODE}`
+- Title: `Code Review: {VENTURE_NAME} - {YYYY-MM-DD}`
+
+Content format:
+
+```
+## Code Review Scorecard
+
+**Date:** {YYYY-MM-DD}
+**Venture:** {VENTURE_NAME} ({VENTURE_CODE})
+**Scope:** {FOCUS_PATH or "Full codebase"}
+**Mode:** {Quick/Full}
+**Models:** {Claude / Claude+Codex+Gemini}
+
+### Grades
+
+| Dimension | Grade | Trend |
+|-----------|-------|-------|
+| Architecture | {A-F} | {up/down/stable/new} |
+| Security | {A-F} | {up/down/stable/new} |
+| Code Quality | {A-F} | {up/down/stable/new} |
+| Testing | {A-F} | {up/down/stable/new} |
+| Dependencies | {A-F} | {up/down/stable/new} |
+| Documentation | {A-F} | {up/down/stable/new} |
+| Golden Path | {A-F} | {up/down/stable/new} |
+
+**Overall: {GRADE}** {trend vs last review}
+
+### Top Findings
+
+1. [{severity}] {description} ({file})
+2. ...
+3. ...
+
+### Previous Issue Resolution
+
+{N}/{M} findings from last review resolved.
+```
+
+**7b. Full Report**
+
+Write the complete report to `docs/reviews/code-review-{YYYY-MM-DD}.md` in the current repo.
+
+Create the `docs/reviews/` directory if it doesn't exist (via Bash `mkdir -p`).
+
+Full report format:
+
+```markdown
+# Code Review: {VENTURE_NAME}
+
+**Date:** {YYYY-MM-DD}
+**Reviewer:** Claude Code (automated)
+**Scope:** {FOCUS_PATH or "Full codebase"}
+**Mode:** {Quick/Full}
+**Models Used:** {list}
+**Golden Path Tier:** {TIER}
+
+## Summary
+
+{Overall grade and 2-3 sentence summary}
+
+## Scorecard
+
+{Same grades table as VCMS scorecard}
+
+## Detailed Findings
+
+### 1. Architecture
+
+{All findings with severity, file:line, description, recommendation}
+
+Grade: {GRADE}
+Rationale: {Why this grade per the rubric}
+
+### 2. Security
+
+{...}
+
+### 3. Code Quality
+
+{...}
+
+### 4. Testing
+
+{...}
+
+### 5. Dependencies
+
+{...}
+
+### 6. Documentation
+
+{...}
+
+### 7. Golden Path Compliance
+
+{...}
+
+## Model Convergence
+
+{If multi-model: which findings were flagged by multiple models}
+
+## Trend Analysis
+
+{Comparison with previous review, if available}
+
+## File Manifest
+
+{Summary: file count, line count, languages}
+
+## Raw Model Outputs
+
+### Claude Review
+
+{CLAUDE_REVIEW}
+
+### Codex Review
+
+{CODEX_REVIEW or "Skipped"}
+
+### Gemini Review
+
+{GEMINI_REVIEW or "Skipped"}
+```
+
+### Step 8: Create GitHub Issues (Optional)
+
+If there are any critical or high severity findings, ask the Captain:
+
+**"Found {N} critical/high findings. Create GitHub issues for tracking?"**
+
+Options:
+
+- **"Yes, create issues"** - Create one issue per finding
+- **"No, report only"** - Skip issue creation
+
+If approved, for each critical/high finding, create a GitHub issue:
+
+```bash
+gh issue create --repo {ORG}/{REPO_NAME} \
+  --title "[Code Review] {brief description}" \
+  --body "{detailed finding with file, line, recommendation}" \
+  --label "source:code-review,type:tech-debt,severity:{severity}"
+```
+
+On subsequent reviews, before creating new issues, query for existing `source:code-review` issues to avoid duplicates:
+
+```bash
+gh issue list --repo {ORG}/{REPO_NAME} --label "source:code-review" --state open --json number,title
+```
+
+If an existing open issue covers the same finding, skip creation and note it in the report.
+
+### Step 9: Done
+
+Display a summary:
+
+```
+Review complete.
+
+Overall Grade: {GRADE} {trend}
+VCMS Scorecard: stored (tag: code-review)
+Full Report: docs/reviews/code-review-{date}.md
+Issues Created: {N} (or "none")
+
+Top action items:
+1. {Most important finding}
+2. {Second most important}
+3. {Third most important}
+```
+
+Do NOT automatically commit the full report. The user may want to review it first.
+
+After displaying the summary, record the completion in the Cadence Engine:
+
+```
+crane_schedule(action: "complete", name: "code-review-{VENTURE_CODE}", result: "success", summary: "Grade: {GRADE}, {N} issues created", completed_by: "crane-mcp")
+```
+
+---
+
+## Grading Rubric
+
+Concrete thresholds per dimension. The grade is determined by the most severe finding, adjusted by count.
+
+### Architecture
+
+- **A:** Clean module boundaries, consistent file organization, no files > 500 lines, clear separation of concerns.
+- **B:** Minor organizational inconsistencies (1-2 files slightly large, one unclear boundary).
+- **C:** 3+ files exceeding 500 lines OR unclear domain boundaries OR mixed concerns in route handlers.
+- **D:** Monolithic structure with significant coupling OR god objects OR no discernible architecture.
+- **F:** Single-file application at scale OR circular dependencies OR architecture prevents safe modification.
+
+### Security
+
+- **A:** All checklist items pass, no findings.
+- **B:** 1-2 low-severity findings only (e.g., overly permissive CORS in dev, missing rate limiting on non-sensitive endpoint).
+- **C:** Any medium-severity finding OR 3+ low-severity (e.g., missing input validation on user-facing endpoint, no rate limiting).
+- **D:** Any high-severity finding (e.g., SQL injection possible, auth bypass on non-critical path, secrets in non-production config).
+- **F:** Any critical finding (exposed secrets in code, SQL injection on production endpoint, missing auth on sensitive endpoints, XSS in user-facing output).
+
+### Code Quality
+
+- **A:** Strict TypeScript, consistent error handling, clean naming, no DRY violations, no dead code.
+- **B:** 1-2 minor issues (occasional `any` type, one duplicated pattern).
+- **C:** `strict: false` in tsconfig OR 3+ `any` usages OR inconsistent error handling patterns OR notable DRY violations.
+- **D:** Pervasive `any` usage OR swallowed errors OR significant dead code OR no consistent patterns.
+- **F:** No TypeScript strictness, errors silently swallowed throughout, fundamentally inconsistent codebase.
+
+### Testing
+
+- **A:** Test framework configured, meaningful tests covering critical paths, good assertion quality, proper mocking.
+- **B:** Tests exist but minor gaps (1-2 untested important paths, slightly weak assertions).
+- **C:** Test framework present but significant gaps OR tests are mostly smoke tests OR critical paths untested.
+- **D:** Minimal tests (< 5 test cases for a non-trivial codebase) OR tests that don't meaningfully verify behavior.
+- **F:** No test framework configured OR no tests at all.
+
+### Dependencies
+
+- **A:** No audit vulnerabilities, all major versions current (within 1 major), no unused dependencies.
+- **B:** Low-severity audit findings only OR 1 major version behind on a key dependency.
+- **C:** Medium-severity audit findings OR 2+ major versions behind OR 3+ unused dependencies.
+- **D:** High-severity audit findings OR severely outdated dependencies (3+ major versions behind).
+- **F:** Critical audit vulnerabilities OR dependencies with known exploits in use.
+
+### Documentation
+
+- **A:** Complete CLAUDE.md with commands + build instructions, README with setup guide, API docs present, schema documented.
+- **B:** CLAUDE.md and README exist and are useful but missing 1-2 sections (e.g., no API docs but README covers basics).
+- **C:** CLAUDE.md exists but incomplete OR README is a stub OR no API documentation for a project with API endpoints.
+- **D:** CLAUDE.md is a template/stub OR no README OR documentation significantly out of date.
+- **F:** No CLAUDE.md OR no documentation at all.
+
+### Golden Path Compliance
+
+- **A:** All tier-appropriate requirements met. No exceptions.
+- **B:** All critical requirements met, 1-2 non-critical items missing (e.g., missing `.gitleaks.toml` at Tier 1).
+- **C:** 1 critical Tier requirement missing OR 3+ non-critical items missing.
+- **D:** Multiple critical Tier requirements missing (e.g., no CI at Tier 1, no error monitoring at Tier 2).
+- **F:** Fundamental Golden Path requirements absent (no source control standards, no TypeScript, hardcoded secrets).
+
+---
+
+## Error Handling
+
+Graceful degradation is the core principle. A review always produces output even if external models fail.
+
+- **Codex fails:** Log reason, continue with Claude + Gemini. Note in report: "Codex: unavailable ({reason})."
+- **Gemini fails:** Log reason, continue with Claude + Codex. Note in report: "Gemini: unavailable ({reason})."
+- **Both fail:** Claude-only review still produces a full report with all 7 dimensions graded. Note in report: "Single-model review (Claude only)."
+- **VCMS unavailable:** Write full report to disk. Warn: "VCMS scorecard could not be stored. Report saved to disk only."
+- **GitHub CLI unavailable:** Skip issue creation and resolution tracking. Warn in report.
+
+Every external call has a timeout and skip-on-failure path. No external failure blocks the review.
+
+---
+
+## Notes
+
+- **Phase 1** ships with a single Claude agent, Claude-only. This validates the grading rubric, VCMS format, and report structure before adding multi-model complexity.
+- **Phase 2** adds 3 parallel agents and Codex/Gemini integration. The `--quick` flag provides an escape hatch for when multi-model cost isn't justified.
+- **Codex cost warning:** Codex exec is an agentic loop with unpredictable cost ($2-8 per run). The `--quick` flag exists for routine reviews.
+- **VCMS tag:** `code-review`. Scorecards are venture-scoped.
+- **Report location:** `docs/reviews/code-review-{YYYY-MM-DD}.md` in the reviewed repo.
+- **Issue labels:** `source:code-review`, `type:tech-debt`, `severity:{level}`.
+- The 7 review dimensions are purpose-built for automated review. They differ from the manual NFR assessment template - a11y requires browser testing (not automatable here), CI/CD is covered by the golden-path-audit.sh script.
+- The `sync-commands.sh` script distributes this command to all venture repos. `/enterprise-review` stays in crane-console only.

--- a/.claude/commands/critique.md
+++ b/.claude/commands/critique.md
@@ -1,0 +1,187 @@
+# /critique - Plan Critique & Auto-Revision
+
+This command spawns critic subagents to challenge the current plan or approach in conversation, then auto-revises based on the critique.
+
+No files required - works against whatever plan, proposal, or approach is in the current conversation context.
+
+## Arguments
+
+```
+/critique [agents]
+```
+
+- `agents` - number of critic agents to spawn in parallel (default: **1**). More agents = more perspectives, but slower and more expensive.
+  - **1 agent**: Comprehensive critic. Fast. Good for quick sanity checks.
+  - **2-3 agents**: Multiple specialized perspectives. Good for important decisions.
+  - **4+ agents**: Full panel. Use sparingly - for high-stakes architectural or strategic decisions.
+
+Parse the argument: if `$ARGUMENTS` is empty or not a number, default to 1. If it's a number, use that value.
+
+Store as `AGENT_COUNT`.
+
+## Execution
+
+### Step 1: Identify the Plan
+
+Scan the current conversation for the most recent plan, approach, or proposal. This could be:
+
+- A plan written during plan mode
+- A proposed implementation approach
+- A technical design or architecture decision
+- A strategy or workflow proposal
+- Any structured "here's what I'm going to do" statement
+
+**If no plan is identifiable**, stop and tell the user:
+
+> I don't see a plan or proposal in our current conversation to critique.
+>
+> Describe your approach first, then run `/critique`.
+
+**If a plan IS found**, capture it as `PLAN_TEXT` and display a brief confirmation:
+
+```
+Critiquing: {one-line summary of what's being critiqued}
+Agents: {AGENT_COUNT}
+```
+
+Do NOT ask for confirmation - proceed immediately.
+
+### Step 2: Assign Critic Perspectives
+
+Select perspectives based on `AGENT_COUNT`. Always assign from the top of this list:
+
+| #   | Perspective               | Focus                                                                                                   |
+| --- | ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| 1   | Devil's Advocate          | Flaws, risks, edge cases, false assumptions, failure modes. "What could go wrong?"                      |
+| 2   | Simplifier                | Over-engineering, unnecessary complexity, simpler alternatives. "Is there a simpler way?"               |
+| 3   | Pragmatist                | Feasibility, hidden costs, timeline realism, operational burden. "Will this actually work in practice?" |
+| 4   | Contrarian                | Fundamentally different approaches, paradigm challenges. "What if the entire framing is wrong?"         |
+| 5   | User/Stakeholder Advocate | End-user impact, UX consequences, stakeholder concerns. "How does this affect the people who use it?"   |
+| 6   | Security & Reliability    | Failure modes, data integrity, security surface, recovery paths. "How does this break?"                 |
+
+- **1 agent** gets "Devil's Advocate" (the comprehensive default - covers risks, gaps, AND simpler alternatives in one pass).
+- **2+ agents** each get a distinct perspective from the list above.
+- **If AGENT_COUNT exceeds 6**, wrap around and assign "Senior" variants (e.g., agent 7 = "Senior Devil's Advocate" with instruction to dig deeper than agent 1).
+
+### Step 3: Spawn Critic Agents
+
+Launch `AGENT_COUNT` agents **in a single message** using the Task tool (`subagent_type: general-purpose`).
+
+**CRITICAL**: All Task tool calls MUST be in a single message to run in true parallel.
+
+Each agent receives:
+
+- The full `PLAN_TEXT`
+- Their assigned perspective
+- Conversation context summary (what problem is being solved, key constraints mentioned)
+
+Agent prompt template:
+
+```
+You are a {PERSPECTIVE_NAME} critic reviewing a plan. Your job is to find weaknesses and suggest improvements from your specific angle.
+
+## The Plan Being Critiqued
+
+{PLAN_TEXT}
+
+## Context
+
+{BRIEF_SUMMARY_OF_WHAT_PROBLEM_IS_BEING_SOLVED_AND_KEY_CONSTRAINTS}
+
+## Your Perspective: {PERSPECTIVE_NAME}
+
+{PERSPECTIVE_DESCRIPTION}
+
+## Instructions
+
+1. Start with `## {PERSPECTIVE_NAME} Critique`
+2. **Strengths** (1-3 bullets): What's good about this plan? Acknowledge what works before attacking.
+3. **Issues Found** (numbered list): Each issue must include:
+   - **The problem**: What's wrong or risky
+   - **Why it matters**: Impact if ignored
+   - **Suggested fix**: A concrete alternative or mitigation - not just "think about this more"
+4. **Alternative Approach** (optional): If you see a fundamentally better path, describe it briefly. Only include this if the alternative is genuinely superior, not just different.
+5. **Verdict**: One line - "Proceed as-is", "Proceed with fixes", or "Reconsider approach"
+
+CONSTRAINTS:
+- Be specific and concrete. "This might have issues" is useless. "The database query in step 3 will table-scan because there's no index on user_id" is useful.
+- Every issue MUST have a suggested fix. Critique without solutions is just complaining.
+- Don't pad. If the plan is solid from your perspective, say so in 2-3 lines and move on. A short critique of a good plan is more valuable than a long critique full of nitpicks.
+- Prioritize. If you find 10 issues, lead with the 3 that matter most.
+- Do NOT write files. Return your critique as your final response message.
+```
+
+Wait for all agents to complete.
+
+### Step 4: Synthesize (if AGENT_COUNT > 1)
+
+If multiple critics ran, synthesize their output before revising:
+
+1. Read all critic responses
+2. Deduplicate overlapping issues (if 2+ critics flagged the same thing, note the convergence - it's more credible)
+3. Rank issues by severity and frequency
+4. Note any contradictions between critics (one says "too simple," another says "too complex")
+5. Present a brief **Critique Summary**:
+
+```
+## Critique Summary ({AGENT_COUNT} perspectives)
+
+### Consensus Issues (flagged by 2+ critics)
+- ...
+
+### Unique Issues
+- ...
+
+### Contradictions
+- ...
+
+### Verdicts
+- Devil's Advocate: Proceed with fixes
+- Simplifier: Reconsider approach
+- ...
+```
+
+If `AGENT_COUNT == 1`, skip synthesis - use the single critic's output directly.
+
+### Step 5: Auto-Revise
+
+Using the critique (or synthesized critique), revise the plan:
+
+1. Address each issue that has a "Suggested fix" - apply fixes that improve the plan without changing its fundamental intent
+2. If a critic suggested "Reconsider approach" AND provided a concrete alternative, evaluate whether the alternative is genuinely better. If so, adopt it. If not, note why the original approach is preferred despite the criticism.
+3. If critics contradicted each other, make a judgment call and note the tradeoff
+4. Do NOT address nitpicks that don't materially improve the plan
+
+Present the revised plan clearly:
+
+```
+## Revised Plan
+
+{THE_REVISED_PLAN}
+
+### Changes Made
+1. {What changed and why, referencing which critic triggered it}
+2. ...
+
+### Critiques Acknowledged but Not Adopted
+1. {What was raised, why it wasn't adopted}
+```
+
+### Step 6: Done
+
+After presenting the revised plan, ask:
+
+**"Revised plan above. Want to proceed, run another round of critique, or adjust something?"**
+
+Do NOT automatically start implementing. Wait for the user.
+
+---
+
+## Notes
+
+- **No files written**: Critique and revision happen in conversation, not on disk. The plan isn't a file - it's the working approach.
+- **Context-dependent**: The quality of critique depends on how much context is in the conversation. A vague "I'll fix the bug" produces vague critique. A detailed technical plan produces detailed critique.
+- **Fast by default**: 1 agent, no confirmation step, auto-revise. The whole flow should complete in one shot.
+- **Agent type**: All critic agents use `subagent_type: general-purpose` via the Task tool.
+- **Parallelism**: All agents launch in a single message for true parallel execution.
+- **No rounds**: Unlike `/prd-review` and `/design-brief`, critique is single-pass by design. If the user wants another round, they run `/critique` again - the revised plan is now the conversation context.

--- a/.claude/commands/design-brief.md
+++ b/.claude/commands/design-brief.md
@@ -1,0 +1,606 @@
+# /design-brief - Multi-Agent Design Brief Generator
+
+This command orchestrates a 4-agent design brief process with configurable rounds. It reads the PRD and existing design artifacts, runs structured design rounds with parallel agents, and synthesizes the output into a production-ready design brief.
+
+The design brief answers "how should this look and feel?" - downstream of the PRD ("what to build and why?"). It requires a PRD to exist before running.
+
+Works in any venture console that has `docs/pm/prd.md`.
+
+## Arguments
+
+```
+/design-brief [rounds]
+```
+
+- `rounds` - number of design rounds (default: **1**). Each additional round adds cross-pollination where agents read and respond to each other's work.
+  - **1 round**: Independent analysis + synthesis. Fast. Good for greenfield projects or early design exploration.
+  - **2 rounds**: Adds cross-pollination. Agents revise after reading all Round 1 output.
+  - **3 rounds**: Full process. Adds final polish round with open design decisions. Best for mature products heading into implementation.
+
+Parse the argument: if `$ARGUMENTS` is empty or not a number, default to 1. If it's a number, use that value. There is no upper bound - if someone wants 5 rounds, run 5 rounds.
+
+Store as `TOTAL_ROUNDS`.
+
+## Execution
+
+### Step 1: Locate Source Documents
+
+**PRD (required)**
+
+Check for `docs/pm/prd.md`. If it does not exist, stop and tell the user:
+
+> I couldn't find a PRD at `docs/pm/prd.md`.
+>
+> The design brief is downstream of product definition - it needs a PRD to work from.
+>
+> Run `/prd-review` first to generate a PRD, then re-run `/design-brief`.
+
+**Enrichment sources (optional)**
+
+Search for additional design context. These are optional - proceed without them if not found:
+
+1. **Executive summary** - Use `crane_notes` MCP tool to search for notes with tag `executive-summary` scoped to the current venture (determine venture code from repo name, e.g., `ke-console` → `ke`)
+2. **Design tokens** - Glob for `**/globals.css` and `**/tailwind.config.*`
+3. **Component library** - Glob for `**/components/ui/**/index.{ts,tsx,js,jsx}` (barrel exports only)
+4. **Design charter** - Check `docs/design/charter.md` or glob `docs/design/*.md`
+5. **Live site** - Check for a deploy URL in the PRD, project instructions, or package.json (`homepage` field). If found, use WebFetch to capture the current state.
+
+Display a **Design Artifact Inventory** table showing what was found:
+
+| Source            | Status            | Path / Details           |
+| ----------------- | ----------------- | ------------------------ |
+| PRD               | Found             | `docs/pm/prd.md`         |
+| Executive Summary | Found / Not found | VCMS note or -           |
+| Design Tokens     | Found / Not found | path or -                |
+| Component Library | Found / Not found | path (N components) or - |
+| Design Charter    | Found / Not found | path or -                |
+| Live Site         | Found / Not found | URL or -                 |
+
+### Step 2: Extract and Confirm Design Context
+
+Read the PRD and all found enrichment sources. Extract the following into a confirmation table:
+
+| Field                | Value                                                               |
+| -------------------- | ------------------------------------------------------------------- |
+| Product Name         | _(from PRD)_                                                        |
+| Tagline              | _(from PRD)_                                                        |
+| Tech Stack           | _(from PRD)_                                                        |
+| Primary Platform     | _(from PRD)_                                                        |
+| Target User          | _(from PRD)_                                                        |
+| Emotional Context    | _(from PRD - what emotional state is the user in when using this?)_ |
+| **Design Maturity**  | _(from filesystem scan - see classification below)_                 |
+| Existing Palette     | _(from globals.css custom properties, or "None")_                   |
+| Component Count      | _(from ui/ barrel exports, or "0")_                                 |
+| Dark Mode            | _(from globals.css: "Implemented" / "Partial" / "None")_            |
+| Accessibility Target | _(from PRD/charter, or default "WCAG 2.1 AA")_                      |
+
+**Design Maturity classification** (critical - this changes agent behavior):
+
+- **Greenfield**: No design tokens, no components. Agents propose everything from scratch - concrete hex values, type scales, spacing systems.
+- **Tokens defined**: globals.css has CSS custom properties, minimal components (0-2). Agents respect existing tokens and extend the system.
+- **Full system**: Design tokens + 3 or more components in ui/. Agents refine, document, and fill gaps - they do not replace what exists.
+
+Also display: **"Running {TOTAL_ROUNDS} round(s) with 4 design agents. Design Maturity: {MATURITY}."**
+
+Present the table and ask the user: **"Does this look right? Anything to correct before I start the design brief?"**
+
+Wait for confirmation. If user provides corrections, note them - they become additional context for all agents.
+
+### Step 3: Handle Previous Runs
+
+Check if `docs/design/contributions/` exists.
+
+If it does:
+
+1. Create archive directory: `docs/design/contributions-archive/` (if it doesn't exist)
+2. Move the entire `docs/design/contributions/` directory to `docs/design/contributions-archive/{ISO-date}/` where `{ISO-date}` is today's date (e.g., `2026-02-13`)
+3. Tell the user: "Archived previous run to `docs/design/contributions-archive/{ISO-date}/`"
+
+If the archive date directory already exists (second run same day), append a counter: `{ISO-date}-2`, `{ISO-date}-3`, etc.
+
+### Step 4: Create Directory Structure
+
+Create round directories for each round that will be run:
+
+```bash
+for N in 1..TOTAL_ROUNDS:
+  mkdir -p docs/design/contributions/round-{N}
+```
+
+### Step 5: Run Design Rounds
+
+Execute `TOTAL_ROUNDS` rounds sequentially. For each round N (from 1 to TOTAL_ROUNDS):
+
+---
+
+**If N == 1 (first round - always independent analysis):**
+
+Launch **4 parallel agents** in a single message using the Task tool (`subagent_type: general-purpose`).
+
+**CRITICAL**: All 4 Task tool calls MUST be in a single message to run in true parallel.
+
+Each agent receives:
+
+- The full content of the PRD
+- The executive summary (if found)
+- Design artifact contents: globals.css custom properties, component barrel export contents, charter
+- The Design Maturity classification and what it means for their work
+- Their role brief (from Role Definitions below)
+- Any user corrections from Step 2
+- Output path: `docs/design/contributions/round-1/{role-slug}.md`
+
+Agent prompt template for Round 1:
+
+```
+You are the {ROLE_NAME} on a design brief panel. Your job is to analyze the PRD and existing design artifacts, then write a comprehensive contribution from your role's perspective.
+
+## PRD
+
+{FULL_TEXT_OF_PRD}
+
+## Executive Summary
+
+{EXECUTIVE_SUMMARY_OR_"Not available"}
+
+## Design Artifacts
+
+### Design Tokens (globals.css)
+{GLOBALS_CSS_CONTENT_OR_"No design tokens found - this is a greenfield project."}
+
+### Component Library
+{BARREL_EXPORT_CONTENTS_OR_"No components found - this is a greenfield project."}
+
+### Design Charter
+{CHARTER_CONTENT_OR_"No design charter found."}
+
+### Live Site
+{LIVE_SITE_SUMMARY_OR_"No live site available."}
+
+## Design Maturity: {MATURITY_LEVEL}
+
+{MATURITY_DESCRIPTION - explain what this means for the agent's work:
+- Greenfield: "No existing design system. Propose concrete values - specific hex colors, font stacks, spacing scales. Do not say 'choose a primary color' - choose it."
+- Tokens defined: "Existing CSS custom properties found. Respect these values. Extend the system - don't replace it. Propose additions that are consistent with what exists."
+- Full system: "Mature design system with tokens and components. Your job is to refine, document gaps, and ensure consistency - not to redesign."}
+
+{USER_CORRECTIONS_IF_ANY}
+
+## Your Role
+
+{ROLE_BRIEF}
+
+## Output Requirements
+
+- Write your contribution as a single markdown file
+- Start with a header: `# {ROLE_NAME} Contribution - Design Brief Round 1`
+- Include metadata: Author, Date ({TODAY}), Design Maturity: {MATURITY_LEVEL}
+- Use `##` for major sections, `###` for subsections
+- Be specific and concrete - no hand-waving. Provide actual values, not placeholders.
+- Reference specific features and screens from the PRD
+- The PRD is the source of truth for what to build. You define how it should look and feel.
+
+Write the file to: {OUTPUT_PATH}
+```
+
+Wait for all 4 agents to complete before proceeding.
+
+Tell the user: **"Round 1 complete. All 4 design agents have written their independent analyses."**
+
+---
+
+**If N > 1 and N < TOTAL_ROUNDS (middle round - cross-pollination):**
+
+Read ALL 4 output files from round N-1. Then launch **4 parallel agents** in a single message.
+
+Each agent receives:
+
+- The PRD and enrichment sources (same as Round 1)
+- ALL 4 contributions from round N-1 (the full text)
+- Their role brief
+- Output path: `docs/design/contributions/round-{N}/{role-slug}.md`
+
+Agent prompt template for middle rounds:
+
+```
+You are the {ROLE_NAME} on a design brief panel. This is Round {N}. You've read all Round {N-1} contributions from all 4 design roles. Revise your contribution based on what you've learned.
+
+## PRD
+
+{FULL_TEXT_OF_PRD}
+
+## Executive Summary
+
+{EXECUTIVE_SUMMARY_OR_"Not available"}
+
+## Design Artifacts
+
+### Design Tokens (globals.css)
+{GLOBALS_CSS_CONTENT_OR_"No design tokens found."}
+
+### Component Library
+{BARREL_EXPORT_CONTENTS_OR_"No components found."}
+
+### Design Charter
+{CHARTER_CONTENT_OR_"No design charter found."}
+
+## Design Maturity: {MATURITY_LEVEL}
+
+{MATURITY_DESCRIPTION}
+
+## Round {N-1} Contributions (All 4 Roles)
+
+### Brand Strategist - Round {N-1}
+{BRAND_STRATEGIST_PREVIOUS_ROUND_TEXT}
+
+### Interaction Designer - Round {N-1}
+{INTERACTION_DESIGNER_PREVIOUS_ROUND_TEXT}
+
+### Design Technologist - Round {N-1}
+{DESIGN_TECHNOLOGIST_PREVIOUS_ROUND_TEXT}
+
+### Target User - Round {N-1}
+{TARGET_USER_PREVIOUS_ROUND_TEXT}
+
+{USER_CORRECTIONS_IF_ANY}
+
+## Your Role
+
+{ROLE_BRIEF}
+
+## Round {N} Requirements
+
+- Start with `# {ROLE_NAME} Contribution - Design Brief Round {N}`
+- Include metadata: Author, Date ({TODAY}), Design Maturity: {MATURITY_LEVEL}, Status: Revised after cross-role review
+- Your FIRST section after metadata MUST be `## Changes from Round {N-1}` with a numbered list of key revisions. For each: what changed, why, which role's input triggered it.
+- Then write your full revised contribution (not just a diff - the complete document)
+- Resolve contradictions you see between roles
+- Fill gaps identified by other roles
+- Cross-reference other roles: "The Brand Strategist proposed...", "The Target User reacted..."
+- The PRD is the source of truth for what to build. You define how it should look and feel.
+
+Write the file to: {OUTPUT_PATH}
+```
+
+Wait for all 4 agents to complete.
+
+Tell the user: **"Round {N} complete. All 4 design agents have revised based on cross-role input."**
+
+---
+
+**If N == TOTAL_ROUNDS and N > 1 (final round - polish + open design decisions):**
+
+Read ALL 4 output files from round N-1. Then launch **4 parallel agents** in a single message.
+
+Each agent receives:
+
+- The PRD and enrichment sources (same as previous rounds)
+- ALL 4 contributions from round N-1 (the full text)
+- Their role brief
+- Output path: `docs/design/contributions/round-{N}/{role-slug}.md`
+
+Agent prompt template for the final round:
+
+```
+You are the {ROLE_NAME} on a design brief panel. This is Round {N} (FINAL). You've read all Round {N-1} contributions. Write your final, polished contribution.
+
+## PRD
+
+{FULL_TEXT_OF_PRD}
+
+## Executive Summary
+
+{EXECUTIVE_SUMMARY_OR_"Not available"}
+
+## Design Artifacts
+
+### Design Tokens (globals.css)
+{GLOBALS_CSS_CONTENT_OR_"No design tokens found."}
+
+### Component Library
+{BARREL_EXPORT_CONTENTS_OR_"No components found."}
+
+### Design Charter
+{CHARTER_CONTENT_OR_"No design charter found."}
+
+## Design Maturity: {MATURITY_LEVEL}
+
+{MATURITY_DESCRIPTION}
+
+## Round {N-1} Contributions (All 4 Roles)
+
+### Brand Strategist - Round {N-1}
+{BRAND_STRATEGIST_PREVIOUS_ROUND_TEXT}
+
+### Interaction Designer - Round {N-1}
+{INTERACTION_DESIGNER_PREVIOUS_ROUND_TEXT}
+
+### Design Technologist - Round {N-1}
+{DESIGN_TECHNOLOGIST_PREVIOUS_ROUND_TEXT}
+
+### Target User - Round {N-1}
+{TARGET_USER_PREVIOUS_ROUND_TEXT}
+
+{USER_CORRECTIONS_IF_ANY}
+
+## Your Role
+
+{ROLE_BRIEF}
+
+## Round {N} (Final) Requirements
+
+- Start with `# {ROLE_NAME} Contribution - Design Brief Round {N} (Final)`
+- Include metadata: Author, Date ({TODAY}), Design Maturity: {MATURITY_LEVEL}, Status: Final after {N} rounds
+- Your FIRST section after metadata MUST be `## Changes from Round {N-1}` with a numbered list of key revisions.
+- Write your full final contribution (complete document, not a diff)
+- Standardize terminology across your document to match consensus from other roles
+- Your LAST section MUST be `## Open Design Decisions` - list genuine design disagreements or unresolved questions that need a human decision. For each:
+  - **The question**: what needs to be decided
+  - **Options considered**: what each role suggested
+  - **Why it matters**: impact on user experience
+  - **My recommendation**: your stance as this role
+  - **Needs**: what type of decision is required (founder call, user testing, A/B test, design spike, etc.)
+- If there are no open design decisions from your perspective, state that explicitly
+- The PRD is the source of truth for what to build. You define how it should look and feel.
+
+Write the file to: {OUTPUT_PATH}
+```
+
+Wait for all 4 agents to complete.
+
+Tell the user: **"Round {N} (final) complete. All contribution files are written. Starting synthesis."**
+
+---
+
+**Special case: TOTAL_ROUNDS == 1**
+
+When only 1 round is run, Round 1 IS the final round. The Round 1 prompt template is used as-is (no "Changes from" or "Open Design Decisions" sections since there's nothing to compare against). Proceed directly to synthesis.
+
+Tell the user: **"Round 1 complete. All 4 design agents have written their analyses. Starting synthesis."**
+
+### Step 6: Synthesis
+
+Read ALL 4 contributions from the final round (round TOTAL_ROUNDS). Synthesize into a single `docs/design/brief.md` following this structure:
+
+```markdown
+# {Product Name} - Design Brief
+
+> Synthesized from {TOTAL_ROUNDS}-round, 4-role design brief process. Generated {TODAY}.
+> Design Maturity: {MATURITY_LEVEL}
+
+## Table of Contents
+
+1. Product Identity
+2. Brand Personality & Design Principles
+3. Target User Context
+4. Visual Language
+5. Screen Inventory & Key Screens
+6. Interaction Patterns
+7. Component System Direction
+8. Technical Constraints
+9. Inspiration & Anti-Inspiration
+10. Design Asks
+11. Open Design Decisions
+```
+
+**Synthesis rules:**
+
+| Section                                  | Primary Source       | Supporting Sources                     |
+| ---------------------------------------- | -------------------- | -------------------------------------- |
+| 1. Product Identity                      | Brand Strategist     | Target User                            |
+| 2. Brand Personality & Design Principles | Brand Strategist     | Target User, Interaction Designer      |
+| 3. Target User Context                   | Target User          | Brand Strategist, Interaction Designer |
+| 4. Visual Language                       | Brand Strategist     | Design Technologist                    |
+| 5. Screen Inventory & Key Screens        | Interaction Designer | Design Technologist                    |
+| 6. Interaction Patterns                  | Interaction Designer | Target User, Design Technologist       |
+| 7. Component System Direction            | Design Technologist  | Interaction Designer                   |
+| 8. Technical Constraints                 | Design Technologist  | Interaction Designer                   |
+| 9. Inspiration & Anti-Inspiration        | Brand Strategist     | Target User                            |
+| 10. Design Asks                          | Interaction Designer | All                                    |
+| 11. Open Design Decisions                | All                  | -                                      |
+
+**Synthesis guidelines:**
+
+- The synthesized brief should read as a unified document, not a collage
+- Brand Strategist's voice is primary for identity and visual language sections
+- Design Technologist is authoritative for technical constraint and component sections
+- Preserve concrete artifacts: hex values, contrast ratios, component specs, ARIA patterns
+- Include the Target User's voice as quoted reactions where relevant (first person, emotional)
+- The Open Design Decisions section collects ALL unresolved items from all final-round contributions, deduplicated. If TOTAL_ROUNDS == 1, this section may be minimal or empty - that's fine.
+- **Design Asks** should be a numbered list of specific, actionable design tasks extracted from all contributions. Each ask should have: title, description, priority (P0/P1/P2), and which role originated it.
+- This file overwrites any existing `docs/design/brief.md` (the contributions are the audit trail)
+
+Tell the user: **"Synthesis complete. Design brief written to `docs/design/brief.md`."**
+
+Provide a brief summary: section count, word count, number of open design decisions flagged, number of design asks, number of rounds run.
+
+### Step 7: Follow-up (Optional)
+
+Ask the user: **"What would you like to do next?"** and present three options:
+
+1. **Store in VCMS** - Save the design brief to the enterprise knowledge store using `crane_note` with tag `design` and the current venture scope.
+
+2. **Create design issues** - Parse the Design Asks section. For each ask, create a GitHub issue via `gh issue create` with the `area:design` label. Present the proposed issue list for approval before creating.
+
+3. **Generate design charter** - If `docs/design/charter.md` does not already exist, offer to generate one. The charter is a governance document that captures: design principles, decision-making process, token naming conventions, component contribution guidelines, and accessibility standards. Write it to `docs/design/charter.md`.
+
+If the user declines all options, finish with: **"Design brief complete. {TOTAL_ROUNDS \* 4} contribution files in `docs/design/contributions/`, synthesized brief at `docs/design/brief.md`."**
+
+---
+
+## Role Definitions
+
+### Brand Strategist
+
+```
+You are the Brand Strategist. You own brand personality, visual identity, and emotional design direction.
+
+YOUR SECTIONS:
+- Brand Personality: 3-5 personality traits with descriptions and "this, not that" examples (e.g., "Warm, not cutesy")
+- Design Principles: 5-7 prioritized principles that guide visual and interaction tradeoffs
+- Color System: primary, secondary, accent, semantic (success/warning/error/info), and neutral palette. Every color as hex value with WCAG AA contrast ratio against its most common background. Light and dark mode variants if applicable.
+- Typography: font stack (Google Fonts or system fonts only - no paid fonts). Scale with specific sizes for h1-h6, body, small, caption. Line heights and letter spacing.
+- Spacing & Rhythm: base unit and scale (e.g., 4px base: 4, 8, 12, 16, 24, 32, 48, 64)
+- Imagery & Iconography: icon style (outline/solid/duo-tone), icon library recommendation, illustration style if applicable, photography direction if applicable
+- Inspiration Board: 3-5 real products/brands that capture the right feel, with specific URLs and what to take from each
+- Anti-Inspiration: 2-3 products/brands that represent the wrong direction, with what to avoid
+
+CONSTRAINTS:
+- If existing design tokens were found (Design Maturity: "Tokens defined" or "Full system"), START from those values. Respect what exists. Propose changes only where the current system has gaps or inconsistencies.
+- If greenfield (Design Maturity: "Greenfield"), propose CONCRETE hex values - never say "choose a primary color." Choose it. Be decisive.
+- All text/background color pairings MUST pass WCAG AA contrast (4.5:1 for normal text, 3:1 for large text). Include the contrast ratio for each pairing.
+- Typography must use only Google Fonts or system font stacks. No paid/licensed fonts.
+- Inspiration references must be real, current products with URLs.
+
+OUTPUT FORMAT:
+- Markdown with ## section headers
+- Color tables with hex values and contrast ratios
+- Type scale as a table with size, weight, line-height, letter-spacing
+- Be decisive and specific - designers need concrete values to implement
+```
+
+### Interaction Designer
+
+```
+You are the Interaction Designer. You own screen inventory, user flows, navigation, and interaction patterns.
+
+YOUR SECTIONS:
+- Screen Inventory: complete list of every MVP screen/page with URL pattern, purpose, and primary action. This must map 1:1 to PRD features - every feature has at least one screen, every screen traces back to a feature.
+- Key Screen Breakdowns: the top 5 most important screens. For each:
+  - Layout description (mobile-first)
+  - Content elements and hierarchy
+  - Primary action and its visual weight
+  - Empty state (what shows when there's no data)
+  - Loading state (skeleton, spinner, or progressive)
+  - Error state (inline, toast, or full-page)
+- Navigation Model: primary nav structure, secondary nav, breadcrumbs if applicable. Max depth. Mobile nav pattern (bottom tabs, hamburger, etc.)
+- User Flows: top 3 critical task flows. Step-by-step: screen → action → screen → result. Include happy path and primary error path.
+- Form Patterns: input styles, validation timing (on-blur, on-submit), error message placement, required field indicators
+- Feedback Patterns: toast/notification style, success confirmations, destructive action confirmations, progress indicators
+- Responsive Strategy: breakpoints, what changes at each breakpoint, mobile-first vs desktop-first
+
+CONSTRAINTS:
+- Screen inventory MUST map 1:1 to PRD features. If the PRD lists a feature, there must be a screen for it. If you list a screen, it must trace to a PRD feature.
+- Mobile-first descriptions. Describe the mobile layout, then note desktop adaptations.
+- Every data-displaying screen MUST specify empty state, loading state, and error state.
+- Max 2 taps/clicks to reach any primary feature from the home screen.
+- User flows must be concrete: "User taps X → sees Y screen → enters Z → taps Submit → sees confirmation toast" - not abstract.
+
+OUTPUT FORMAT:
+- Markdown with ## section headers
+- Tables for screen inventory
+- Step-by-step numbered lists for user flows
+- Be exhaustive on screens - a missing screen becomes a missed feature
+```
+
+### Design Technologist
+
+```
+You are the Design Technologist. You own the component system, token architecture, accessibility, and technical implementation constraints.
+
+YOUR SECTIONS:
+- Component Inventory: every UI component needed for MVP. For each:
+  - Name (PascalCase)
+  - Purpose (one sentence)
+  - Variants (e.g., primary/secondary/ghost for Button)
+  - Key props interface (TypeScript-style)
+  - Status: "Exists" / "Exists (needs update)" / "New" (based on component library scan)
+  - ARIA role/pattern (e.g., role="dialog", combobox pattern)
+- Design Token Architecture:
+  - Naming convention using venture prefix (e.g., --ke-color-primary, --sc-spacing-4)
+  - Token categories: color, spacing, typography, radius, shadow, motion
+  - CSS custom property definitions
+  - Tailwind config mapping (if Tailwind is in the tech stack)
+- CSS Strategy: methodology (utility-first, BEM, CSS modules, etc.), based on tech stack
+- Dark Mode Implementation: strategy (CSS custom properties + class toggle, media query, or both), token structure for light/dark
+- Responsive Implementation: container queries vs media queries, fluid typography, responsive spacing
+- Accessibility:
+  - Focus management strategy (focus trap for modals, skip links, focus restoration)
+  - Keyboard navigation patterns (arrow keys for lists, tab for form fields, escape to close)
+  - ARIA patterns for complex widgets (combobox, tabs, accordion, dialog)
+  - Reduced-motion: what animations to disable, what to replace with crossfade
+  - Screen reader announcements: live regions for dynamic content
+- Performance Budget:
+  - First Contentful Paint: target in ms
+  - Largest Contentful Paint: target in ms
+  - Cumulative Layout Shift: target
+  - Total CSS bundle size: target in KB
+  - Font loading strategy: swap/optional/block
+- Animation & Motion: easing curves, duration scale, what animates and what doesn't
+
+CONSTRAINTS:
+- If existing components were found (Design Maturity: "Full system"), mark each as "Exists" / "Exists (needs update)" / "New." Do not propose replacing existing components.
+- Token naming MUST use venture prefix pattern (e.g., --ke-*, --sc-*, --dfg-*)
+- Every component MUST specify its ARIA role or pattern
+- Performance budget must have specific numbers, not "fast"
+- Animation durations: 100-150ms for micro-interactions, 200-300ms for transitions, 300-500ms for page transitions
+- Accessibility target is WCAG 2.1 AA unless the PRD or charter specifies otherwise
+
+OUTPUT FORMAT:
+- Markdown with ## section headers
+- Tables for component inventory
+- Code blocks for token definitions and CSS examples
+- TypeScript interfaces for component props
+- Be precise - ambiguity in design specs causes inconsistent implementation
+```
+
+### Target User
+
+```
+You are the Target User - the actual person this product is being designed for. Stay in character throughout.
+
+Write in FIRST PERSON. You are not an analyst or a designer - you are the user. React to the design directions as a real person would.
+
+YOUR SECTIONS:
+- Who I Am: brief intro establishing your identity, daily life, and emotional state when you'd use this product
+- My Environment: where and how I use apps like this - device, time of day, attention level, physical context (commuting? at desk? in bed?)
+- First Impressions: if I saw this product for the first time, what would I think? Does it look trustworthy? Professional? Fun? Confusing?
+- Emotional Reactions: go through each key screen described by the Interaction Designer (or inferred from the PRD). How does each one make me feel? What do I notice first? What confuses me?
+- What Feels Right: design patterns from apps I already use that feel natural and good. Name real apps. "I love how Notion does X" or "The way Linear handles Y is perfect"
+- What Would Turn Me Off: specific design anti-patterns that would make me distrust or abandon this product. Be blunt and emotional.
+- Navigation Expectations: how I expect to move through this product. What should be one tap away? What's OK to bury?
+- Make-or-Break Moments: the 2-3 moments in the user experience where design quality will determine if I stay or leave
+
+CONSTRAINTS:
+- First person ONLY. Never break character. Never use design jargon (no "affordance," "heuristic," "information architecture").
+- Be honest, not polite - if something sounds ugly or confusing, say so
+- Reference REAL apps as comparisons (Venmo, Notion, Linear, Instagram, etc.)
+- Express genuine emotion: frustration, delight, anxiety, confusion, trust, skepticism
+- React to WHAT'S DESCRIBED in the PRD, not what you wish existed
+- "If it looks like a government website I'm leaving" - that level of honesty
+- Your reactions should reflect the emotional context from the PRD (stressed parent? busy professional? casual browser?)
+
+OUTPUT FORMAT:
+- First-person narrative prose
+- Conversational tone - this reads like a user interview, not a report
+- Use "I" and "my" throughout
+- Bold or emphasize strong reactions
+- Be blunt and emotional - sugar-coating helps no one
+```
+
+---
+
+## Role-to-Slug Mapping
+
+| Role                 | Slug (filename)        |
+| -------------------- | ---------------------- |
+| Brand Strategist     | `brand-strategist`     |
+| Interaction Designer | `interaction-designer` |
+| Design Technologist  | `design-technologist`  |
+| Target User          | `target-user`          |
+
+---
+
+## Notes
+
+- **PRD is required**: Unlike `/prd-review` which works from project instructions alone, `/design-brief` requires `docs/pm/prd.md` - the design brief is downstream of product definition
+- **Design Maturity drives behavior**: Not a flow control flag, but context that fundamentally changes what agents produce (greenfield = propose everything, full system = refine and extend)
+- **Codebase scanning**: Agents receive CSS token values and component barrel exports, not raw component source code
+- **4 roles not 6**: Design is more focused than product definition; 6 roles would produce redundancy
+- **Output in `docs/design/`**: Design artifacts are a separate concern from PM artifacts in `docs/pm/`
+- **Re-runs are safe**: Previous contributions are archived before a new run starts
+- **Source documents are not modified**: Only `docs/design/brief.md` is written (overwritten)
+- **Contributions are the audit trail**: `TOTAL_ROUNDS * 4` files show how the design brief evolved
+- **Agent type**: All role agents use `subagent_type: general-purpose` via the Task tool
+- **Parallelism**: Each round launches all 4 agents in a single message for true parallel execution
+- **Context size**: Round 2+ agents receive large prompts (all previous round outputs). This is expected and necessary for cross-pollination.
+- **Default is 1 round**: Fast and sufficient for most use cases. Use more rounds when the design system is mature and heading into implementation.

--- a/.claude/commands/edit-article.md
+++ b/.claude/commands/edit-article.md
@@ -1,0 +1,284 @@
+# /edit-article - Editorial Review Agent
+
+This command runs an article through two parallel editor agents, applies blocking fixes directly, and reports what changed. Advisory issues are reported but not auto-fixed.
+
+## Arguments
+
+```
+/edit-article <path>
+```
+
+- `path` - path to the article markdown file (required)
+
+Parse the argument: if `$ARGUMENTS` is empty, scan `~/dev/vc-web/src/content/articles/` for files with `draft: true` in their YAML frontmatter. List them and ask the user to pick one using AskUserQuestion. If no drafts found, tell the user: "No draft articles found. Provide a path: `/edit-article <path>`"
+
+If `$ARGUMENTS` is provided, use it as the article path.
+
+## Pre-flight
+
+Before spawning agents, do these checks in order:
+
+1. **Terminology doc**: Resolve `~/dev/vc-web/docs/content/terminology.md`. Read it. If it doesn't exist, stop: "Terminology doc not found at ~/dev/vc-web/docs/content/terminology.md. Cannot run editorial review."
+2. **Venture registry**: Read `~/dev/crane-console/config/ventures.json`. If missing, stop: "Venture registry not found."
+3. **Article file**: Read the file at `path`. If it doesn't exist, stop: "Article not found at {path}."
+4. **Display**: Extract the `title` from the article's YAML frontmatter. Display: `Editing: {title}` and proceed immediately. Do NOT ask for confirmation.
+
+Store the full content of the terminology doc as `TERMINOLOGY_DOC`.
+Store the venture registry as `VENTURE_REGISTRY`.
+Store the full content of the article as `ARTICLE_TEXT`.
+
+Build a list of **stealth ventures** - any venture where `portfolio.showInPortfolio` is `false`.
+
+Extract **venture-name tags** from the article's frontmatter `tags` field. Recognized venture tags: `kid-expenses`, `durgan-field-guide`, `silicon-crane`, `draft-crane`. Store the matched tags as `ARTICLE_VENTURE_TAGS` (or "None" if no venture tags found).
+
+## Editor Agents (2, launched in parallel)
+
+Launch both agents **in a single message** using the Task tool (`subagent_type: general-purpose`).
+
+**CRITICAL**: Both Task tool calls MUST be in a single message to run in true parallel.
+
+---
+
+### Agent 1: Style & Compliance Editor
+
+Prompt:
+
+```
+You are the Style & Compliance Editor. You check articles against the terminology doc and anonymization rules before publish.
+
+## Terminology Doc (source of truth)
+
+{TERMINOLOGY_DOC}
+
+## Venture Registry
+
+{VENTURE_REGISTRY}
+
+## Stealth Ventures (must not appear at all)
+
+{list of ventures with showInPortfolio: false, with their names and codes}
+
+## Article Venture Tags
+
+{ARTICLE_VENTURE_TAGS}
+
+## Article Under Review
+
+{ARTICLE_TEXT}
+
+## Instructions
+
+Read the article line by line. Check every line against the rules below. Report findings with exact quoted text and line numbers.
+
+### BLOCKING checks (must fix before publish)
+
+**Genericization violations - always blocking (regardless of tags):**
+- Any `crane-*` pattern EXCEPT "Venture Crane" (e.g., crane-context, crane-mcp, crane-classifier, crane-relay are all internal names that must not appear in published articles)
+- Real org names: "venturecrane" in prose (OK in `sources` frontmatter URLs)
+- Real venture codes used as identifiers: vc, ke, sc, dfg, dc (OK in `sources` frontmatter)
+- Specific venture counts: "5 ventures", "six ventures", or any specific number of ventures (these go stale)
+- Legal entity names
+- Stealth venture names or identifiable details (ventures listed as stealth above)
+
+**Venture name genericization - tag-dependent (see Article Venture Tags above):**
+- If the article IS tagged with a venture name (e.g., tags include `kid-expenses`), that venture's proper name ("Kid Expenses") is ALLOWED in prose. Do not flag it.
+- Other public venture names in a tagged article are ADVISORY - report under "### Advisory", suggest genericizing for focus.
+- If the article has NO venture-name tags, ALL public venture names are ADVISORY - report under "### Advisory", suggest genericizing for readability.
+- Stealth ventures are ALWAYS blocking regardless of tags.
+
+**Terminology violations** - per the terminology doc:
+- "product factory" instead of "development lab"
+- "SQLite" alone without "D1" (should be "D1" or "D1/SQLite" on first reference)
+- "secrets manager" alone without naming "Infisical" on first reference
+- Any other violations of the canonical name table in the terminology doc
+
+**Manufactured experience** - flag these patterns, then evaluate context:
+- Patterns: "we discovered", "we learned", "we realized", "we felt", "we believed", "surprised", "it struck us", "it dawned on", "After X years", "In my experience", "Having spent", "I noticed", "I decided", "I wanted"
+- NOT automatic blockers. For each match, evaluate: does the sentence attribute a subjective human experience the agent couldn't have had?
+  - FINE: "We learned from the build logs that usage dropped 40%" (citing evidence)
+  - BLOCKING: "We learned that simplicity matters" (manufacturing wisdom)
+  - FINE: "We discovered the worker was timing out after checking the error logs" (citing debugging)
+  - BLOCKING: "We discovered that less is more" (manufacturing insight)
+
+**Founder-voice fabrication** - any sentence that puts words in the founder's mouth or manufactures a personal anecdote
+
+### ADVISORY checks (should fix)
+
+- Public venture names per the tag-dependent rules above (suggest genericizing for focus where no matching tag exists)
+- Em dashes (should be hyphens)
+- "I" in articles (only "we" or third person per terminology doc)
+- Throat-clearing openers ("In this article, we will...", "Today we're going to...")
+- Marketing language (superlatives, hype, "revolutionary", "game-changing", etc.)
+- Register mismatch (article should be analytical/explanatory, not terse build-log voice)
+
+### Output Format
+
+Start with `## Style & Compliance Editor`
+
+Then:
+
+```
+
+### Blocking (must fix before publish)
+
+1. Line X: "{exact quoted text}" - {rule violated}. Fix: "{exact replacement text}"
+
+### Advisory (should fix)
+
+1. Line X: "{exact quoted text}" - {issue}. Fix: "{exact replacement text}"
+
+### Clean
+
+- {What was checked and passed}
+
+```
+
+If a section has no findings, write "None" under the heading.
+
+CONSTRAINTS:
+- Quote the EXACT text from the article. Do not paraphrase.
+- Include line numbers. Count from line 1 of the raw file (including frontmatter).
+- Every issue MUST include a Fix with the EXACT replacement text that can be used in a find-and-replace operation. The old text and new text must be copy-pasteable.
+- Do NOT write files. Return your report as your final response message.
+```
+
+---
+
+### Agent 2: Fact Checker
+
+Prompt:
+
+```
+You are the Fact Checker. You cross-reference verifiable claims in articles against real sources.
+
+## Article Under Review
+
+{ARTICLE_TEXT}
+
+## Instructions
+
+You have access to tools. Use them to verify claims in the article against real sources. Work through the verification checklist below IN ORDER.
+
+### Verification Checklist
+
+**1. Venture claims**
+Read the venture registry at ~/dev/crane-console/config/ventures.json. Compare to any count, name, or capability claim in the article. Flag mismatches.
+
+**2. Number verification**
+For any token count, file count, line count, percentage, or other specific number in the article: search build logs at ~/dev/vc-web/src/content/logs/*.md for verification. Flag numbers that don't match.
+
+**3. Status claims**
+For anything described as a "current limitation", "not yet", "doesn't yet", "future work", or similar: search build logs and the codebase for evidence it's been resolved. Flag solved problems presented as current limitations.
+
+**4. Feature claims**
+For anything described as working or shipped: verify the component exists. Check for the worker, endpoint, config file, or package - but do NOT deep-read source code. A quick existence check is sufficient.
+
+**5. Cross-article consistency**
+Read other articles at ~/dev/vc-web/src/content/articles/*.md. Flag contradictions between the article under review and other published articles.
+
+### Scope Constraint
+
+Do NOT read arbitrary source code files to verify technical claims. Stick to the checklist above. Use these sources ONLY:
+- ~/dev/crane-console/config/ventures.json (venture registry)
+- ~/dev/vc-web/src/content/logs/*.md (build logs)
+- ~/dev/vc-web/src/content/articles/*.md (other articles)
+- crane_notes MCP tool (enterprise context)
+- crane_status MCP tool (current issue state)
+- Glob/Grep to check if a file, worker, or endpoint EXISTS (not to read implementation)
+
+If a claim cannot be verified from these sources, flag it as "UNVERIFIED - requires manual confirmation" rather than guessing.
+
+### Classification
+
+**BLOCKING (must fix before publish):**
+- Outdated claims: solved problem presented as current limitation
+- Wrong numbers: counts/percentages that don't match build logs
+- Aspirational-as-shipped: features described as working that are designed-but-not-deployed (aspirational content is fine if clearly labeled as future/planned)
+
+**ADVISORY (should fix):**
+- Architecture descriptions that don't match current code structure
+- Cross-article contradictions
+- Claims you couldn't verify (flag as UNVERIFIED)
+
+### Output Format
+
+Start with `## Fact Checker`
+
+Then:
+
+```
+
+### Blocking (must fix before publish)
+
+1. Line X: "{exact quoted text}" - {what's wrong}. Source: {where you checked}. Fix: "{exact replacement text}"
+
+### Advisory (should fix)
+
+1. Line X: "{exact quoted text}" - {issue}. Source: {where you checked}. Fix: "{exact replacement text}"
+
+### Clean
+
+- {What was checked and passed, with source references}
+
+```
+
+If a section has no findings, write "None" under the heading.
+
+CONSTRAINTS:
+- Quote the EXACT text from the article. Do not paraphrase.
+- Include line numbers. Count from line 1 of the raw file (including frontmatter).
+- Every finding MUST cite the source you checked against.
+- Every issue MUST include a Fix with the EXACT replacement text that can be used in a find-and-replace operation. The old text and new text must be copy-pasteable.
+- Do NOT write files. Return your report as your final response message.
+```
+
+---
+
+## Apply Fixes
+
+Wait for both agents to complete. Then:
+
+### Step 1: Apply blocking fixes
+
+Re-read the article file (it may have changed since pre-flight). For each blocking issue from both editors:
+
+1. Use the Edit tool to find the exact quoted text and replace it with the suggested fix
+2. If the quoted text can't be found (line numbers shifted, text was already fixed, etc.), skip it and note it in the report
+3. Deduplicate - if both editors flagged the same text, apply the fix once
+
+### Step 2: Apply advisory fixes
+
+For advisory issues that have clear, mechanical fixes (em dashes, grammar errors, wrong terminology), apply them the same way. Skip advisory issues that require judgment calls or significant rewriting - list those in the report for human review.
+
+### Step 3: Report
+
+After applying fixes, present:
+
+```
+## Editorial Report: {article title}
+
+### Fixed: {count}
+{list of fixes applied, with before/after quotes}
+
+### Requires Human Review: {count}
+{advisory issues that weren't auto-fixed because they need judgment}
+
+### Clean Checks
+{what passed across both editors}
+```
+
+**If nothing was fixed and nothing needs review**: "Editorial review complete. No issues found."
+
+**If fixes were applied**: End with "Applied {N} fix(es). Re-run `/edit-article` to verify." Do NOT automatically re-run - let the user decide.
+
+---
+
+## Notes
+
+- **Auto-fix**: This command fixes blocking issues and mechanical advisory issues directly in the article file.
+- **Human review**: Advisory issues requiring judgment (rewriting sections, tone adjustments, architectural descriptions) are reported but not auto-fixed.
+- **Re-run to verify**: After fixes, run `/edit-article` again to confirm issues are resolved.
+- **Agent type**: Both editor agents use `subagent_type: general-purpose` via the Task tool.
+- **Parallelism**: Both agents launch in a single message for true parallel execution.
+- **No rounds**: Single pass. Re-invoke after fixes to verify.
+- **Terminology doc is the source of truth**: The Style & Compliance Editor checks against it. If the terminology doc is wrong, fix it there - not in the article.

--- a/.claude/commands/edit-log.md
+++ b/.claude/commands/edit-log.md
@@ -1,0 +1,195 @@
+# /edit-log - Build Log Editorial Review
+
+Single-agent editorial review for build logs. Checks genericization and style, auto-fixes blocking issues, reports advisory issues for human judgment.
+
+## Arguments
+
+```
+/edit-log <path>
+```
+
+- `path` - path to the build log markdown file (optional)
+
+Parse the argument: if `$ARGUMENTS` is empty, scan `~/dev/vc-web/src/content/logs/` for files with `draft: true` in their YAML frontmatter. List them and ask the user to pick one using AskUserQuestion. If no drafts found, tell the user: "No draft logs found. Provide a path: `/edit-log <path>`"
+
+If `$ARGUMENTS` is provided, use it as the log path.
+
+## Pre-flight
+
+Before spawning the editor agent, do these checks in order:
+
+1. **Terminology doc**: Read `~/dev/vc-web/docs/content/terminology.md`. If missing, stop: "Terminology doc not found at ~/dev/vc-web/docs/content/terminology.md. Cannot run editorial review."
+2. **Venture registry**: Read `~/dev/crane-console/config/ventures.json`. If missing, stop: "Venture registry not found."
+3. **Log file**: Read the file at `path`. If missing, stop: "Log not found at {path}."
+4. **Existing articles**: Glob `~/dev/vc-web/src/content/articles/*.md` and read their titles and slugs (frontmatter only) for the cross-reference check.
+5. **Display**: Extract the `title` from the log's YAML frontmatter. Display: `Editing: {title}` and proceed immediately. Do NOT ask for confirmation.
+
+Store the full content of the terminology doc as `TERMINOLOGY_DOC`.
+Store the full content of the log as `LOG_TEXT`.
+Store the venture registry as `VENTURE_REGISTRY`.
+Store the article titles/slugs list as `ARTICLE_INDEX`.
+
+Build a list of **stealth ventures** - any venture where `portfolio.showInPortfolio` is `false`.
+
+Extract **venture-name tags** from the log's frontmatter `tags` field. Recognized venture tags: `kid-expenses`, `durgan-field-guide`, `silicon-crane`, `draft-crane`. Store the matched tags as `LOG_VENTURE_TAGS` (or "None" if no venture tags found).
+
+## Editor Agent
+
+Launch one agent using the Task tool (`subagent_type: general-purpose`).
+
+### Agent: Style & Genericization Editor
+
+Prompt:
+
+```
+You are the Style & Genericization Editor for build logs. You check logs against the terminology doc, genericization rules, and style guidelines.
+
+## Terminology Doc (source of truth)
+
+{TERMINOLOGY_DOC}
+
+## Venture Registry
+
+{VENTURE_REGISTRY}
+
+## Stealth Ventures (must not appear at all)
+
+{list of ventures with showInPortfolio: false, with their names and codes}
+
+## Article Index (for cross-reference check)
+
+{ARTICLE_INDEX}
+
+## Log Venture Tags
+
+{LOG_VENTURE_TAGS}
+
+## Build Log Under Review
+
+{LOG_TEXT}
+
+## Instructions
+
+Read the log line by line. Check every line against the rules below. Report findings with exact quoted text and line numbers.
+
+### BLOCKING checks (must fix before publish)
+
+**Genericization violations - always blocking (regardless of tags):**
+- Any `crane-*` pattern EXCEPT "Venture Crane" (e.g., crane-context, crane-mcp, crane-classifier, crane-relay - these are internal names)
+- Real org names: "venturecrane" in prose (OK in the site URL venturecrane.com when referring to the published site)
+- Venture codes used as identifiers: vc, ke, sc, dfg, dc (two-letter codes in technical context)
+- Specific venture counts: "5 ventures", "six ventures", or any specific number of ventures
+- Legal entity names, App IDs (e.g., "2619905"), installation IDs
+- Internal hostnames (mac23, mac-mini-1, etc.)
+- Infisical paths (/vc, /ke, /sc, /dfg, /dc)
+- Stealth venture names, codes, descriptions, or identifiable details - even in genericized form
+
+**Venture name genericization - tag-dependent (see Log Venture Tags above):**
+- If the log IS tagged with a venture name (e.g., tags include `kid-expenses`), that venture's proper name ("Kid Expenses") is ALLOWED in prose. Do not flag it.
+- Other public venture names in a tagged log are ADVISORY - report under "### Advisory", suggest genericizing for focus.
+- If the log has NO venture-name tags, ALL public venture names are ADVISORY - report under "### Advisory", suggest genericizing for readability.
+- Stealth ventures are ALWAYS blocking regardless of tags.
+
+**Terminology violations** - per the terminology doc canonical names table:
+- "product factory" instead of "development lab"
+- "SQLite" alone without "D1"
+- "secrets manager" alone without naming "Infisical" on first reference
+- Any other violations of the canonical name table
+
+For each blocking issue, provide:
+- The EXACT genericized replacement per the terminology doc's Published Content section
+- crane-context -> "the context API" or "the context worker"
+- crane-mcp -> "the MCP server" or "the local MCP server"
+- crane-classifier -> "the GitHub classifier" or "the webhook processor"
+- crane-relay -> "the legacy webhook worker" or "the monolithic worker"
+- Venture codes -> Generic codes (alpha, beta, gamma, etc.)
+- venturecrane org -> Omit or "example-org"
+- Specific counts -> "multiple ventures" or "several projects"
+
+### ADVISORY checks (report but don't auto-fix)
+
+- Public venture names per the tag-dependent rules above (not auto-fixed; suggest genericizing for focus)
+- Em dashes (should be hyphens)
+- Article-register voice: flag analytical or explanatory tone that reads like an article rather than an operational log. Build logs should feel like a field report, not an essay.
+- Numbers that might go stale: specific counts, percentages, or metrics that will become wrong over time
+- Article overlap: search the article index for keyword overlap with the log's content. If found, surface: "This log discusses [topic]. An article on this topic exists at [slug]. Verify consistency."
+
+### NOT checked (explicitly out of scope)
+
+- "I" usage (acceptable in build logs per terminology doc)
+- AI disclosure (BR-006 exempts logs)
+- Fact-checking against other logs (avoids circular checking)
+
+### Output Format
+
+Start with `## Style & Genericization Editor`
+
+Then:
+
+### Blocking (must fix before publish)
+
+1. Line X: "{exact quoted text}" - {rule violated}. Fix: "{exact replacement text}"
+
+### Advisory (should review)
+
+1. Line X: "{exact quoted text}" - {issue}. Suggestion: "{suggested change}"
+
+### Clean
+
+- {What was checked and passed}
+
+If a section has no findings, write "None" under the heading.
+
+CONSTRAINTS:
+- Quote the EXACT text from the log. Do not paraphrase.
+- Include line numbers. Count from line 1 of the raw file (including frontmatter).
+- Every blocking issue MUST include a Fix with the EXACT replacement text that can be used in a find-and-replace operation.
+- Advisory issues include a Suggestion (not a Fix) since they need human judgment.
+- Do NOT write files. Return your report as your final response message.
+```
+
+---
+
+## Apply Fixes
+
+Wait for the agent to complete. Then:
+
+### Step 1: Apply blocking fixes
+
+Re-read the log file (it may have changed since pre-flight). For each blocking issue:
+
+1. Use the Edit tool to find the exact quoted text and replace it with the suggested fix
+2. If the quoted text can't be found (text was already fixed, etc.), skip it and note it in the report
+3. Verify each edit preserves markdown formatting
+
+### Step 2: Report
+
+After applying fixes, present:
+
+```
+## Editorial Report: {log title}
+
+### Fixed: {count}
+{list of fixes applied, with before/after quotes}
+
+### Requires Human Review: {count}
+{advisory issues that need judgment}
+
+### Clean Checks
+{what passed}
+```
+
+**If nothing was fixed and nothing needs review**: "Editorial review complete. No issues found."
+
+**If fixes were applied**: End with "Applied {N} fix(es). Re-run `/edit-log` to verify." Do NOT automatically re-run.
+
+---
+
+## Notes
+
+- **Single agent**: Build logs are 200-1,000 words. One agent with a combined checklist is sufficient.
+- **Auto-fix blocking only**: Genericization violations are mechanical and safe to auto-fix. Advisory issues need human judgment.
+- **Re-run to verify**: After fixes, run `/edit-log` again to confirm issues are resolved.
+- **Agent type**: Uses `subagent_type: general-purpose` via the Task tool.
+- **Terminology doc is the source of truth**: If the terminology doc is wrong, fix it there, not in the log.
+- **No fact-checking**: Unlike `/edit-article`, there's no fact checker agent. Build logs are short operational updates, not claims-heavy articles.

--- a/.claude/commands/eod.md
+++ b/.claude/commands/eod.md
@@ -1,0 +1,97 @@
+# /eod - End of Day Handoff
+
+Auto-generate handoff from session context. The agent summarizes - never ask the user.
+
+## Usage
+
+```
+/eod
+```
+
+## Execution Steps
+
+### 1. Gather Session Context
+
+The agent has full conversation history. Additionally, gather:
+
+```bash
+# Get repo info
+REPO=$(git remote get-url origin | sed -E 's/.*github\.com[:\/]([^\/]+\/[^\/]+)(\.git)?$/\1/')
+
+# Get commits from this session (last 24 hours or since last handoff)
+git log --oneline --since="24 hours ago" --author="$(git config user.name)"
+
+# Get any PRs created/updated today
+gh pr list --author @me --state all --json number,title,state,updatedAt --jq '.[] | select(.updatedAt | startswith("'$(date +%Y-%m-%d)'"))'
+
+# Get issues worked on (from commits or conversation)
+gh issue list --state all --json number,title,state,updatedAt --jq '.[] | select(.updatedAt | startswith("'$(date +%Y-%m-%d)'"))'
+```
+
+### 2. Synthesize Handoff (Agent Task)
+
+Using conversation history and gathered context, the agent generates a summary covering:
+
+**Accomplished:** What was completed this session
+
+- Issues closed/progressed
+- PRs created/merged
+- Problems solved
+- Code changes made
+
+**In Progress:** Unfinished work
+
+- Where things were left off
+- Partial implementations
+- Pending reviews
+
+**Blocked:** Items needing attention
+
+- Blockers encountered
+- Questions for PM
+- Decisions needed
+- External dependencies
+
+**Next Session:** Recommended focus
+
+- Logical next steps
+- Priority items
+- Follow-ups needed
+
+### 3. Show User for Confirmation
+
+Display the generated handoff and ask:
+
+```
+Here's the handoff I generated:
+
+[show handoff content]
+
+Save to D1? (y/n)
+```
+
+Only ask this single yes/no question. Do not ask user to write or edit the summary.
+
+### 4. Save Handoff via MCP
+
+Call the `crane_handoff` MCP tool with:
+
+- `summary`: The synthesized handoff text
+- `status`: One of `in_progress`, `blocked`, or `done` (infer from context)
+- `issue_number`: If a primary issue was being worked on
+
+This writes to D1 via the Crane Context API. The next session's `crane_sod` will read it.
+
+### 5. Report Completion
+
+```
+Handoff saved to D1. Next session will see this via crane_sod.
+```
+
+## Key Principle
+
+**The agent summarizes. The user confirms.**
+
+The agent has full session context - every command run, every file edited, every conversation turn. It should synthesize this into a coherent handoff without asking the user to remember or summarize anything.
+
+The only user input is a yes/no confirmation before saving.

--- a/.claude/commands/go-live.md
+++ b/.claude/commands/go-live.md
@@ -1,0 +1,108 @@
+# /go-live - Venture Go-Live Process
+
+Launch a venture to production with mandatory secret rotation and readiness checks.
+
+```
+/go-live dc           # launch Draft Crane
+/go-live ke           # launch Kid Expenses
+```
+
+**Do NOT follow `docs/process/secrets-rotation-runbook.md`** - it references decommissioned tooling.
+
+## Step 1: Parse & Validate
+
+Parse `$ARGUMENTS` for a venture code. Then:
+
+1. Read `config/ventures.json`
+2. Find the venture by `code`
+3. If not found, stop: "Unknown venture code. Available: {list codes with status}"
+4. If `portfolio.status` is `"launched"`, stop: "Already launched."
+5. If no argument provided, stop with usage: "/go-live {venture-code}"
+
+## Step 2: Pre-flight Checks (automated)
+
+Run these checks without user input. Report pass/fail for each.
+
+1. **Golden Path compliance** - Read `docs/standards/golden-path.md` compliance dashboard row for this venture. Note Sentry, CI/CD, Monitoring, Docs status. If the venture is missing from the dashboard, flag it as a gap.
+2. **Infisical prod secrets** - Run `infisical secrets --path /{venture} --env prod --silent 2>/dev/null | grep '│' | grep -v 'SECRET NAME' | grep -v '├\|┌\|└' | sed 's/│/|/g' | cut -d'|' -f2 | sed 's/^ *//;s/ *$//'` to extract key names only. **NEVER run bare `infisical secrets` - it displays values in the transcript.**
+3. **Infisical dev secrets** - Same key-names-only extraction for `--env dev`.
+4. **Production worker health** - If the venture has a known health endpoint, `curl` it and confirm 200.
+5. **DNS/custom domain** - If `portfolio.url` is set in ventures.json, verify DNS resolves.
+
+Present results as a checklist. If any critical check fails (no prod secrets, no worker health), stop: "Fix these before proceeding."
+
+## Step 3: Secret Inventory
+
+Agent pulls and displays key names only (NEVER values):
+
+1. Extract key names from Infisical (reuse the key-names-only command from Step 2 - NEVER display values).
+2. Read the **Shared Credentials** table from `docs/infra/secrets-management.md`.
+3. Read the **Revocation Behavior by Type** table from `docs/infra/secrets-management.md`.
+4. Cross-reference: flag any shared credentials and note rotation impact.
+5. Categorize each secret by revocation behavior (immediate vs dual-key vs self-generated).
+
+Present the full inventory, then ask via AskUserQuestion:
+
+**Question:** "Rotate all {N} secrets at their sources, update Infisical (prod AND dev), then confirm."
+
+Include in the question context:
+
+- Shared credentials and which ventures they affect
+- Immediate-revocation secrets (test each one right after rotating)
+- Dual-key/self-generated secrets (can batch)
+
+**Options:**
+
+1. "All rotated and updated in Infisical" - proceed to push
+2. "Skip rotation" - launch without rotating (for ventures where secrets were never exposed in transcripts)
+3. "Cancel" - abort go-live
+
+If cancelled, stop.
+
+## Step 4: Push to Workers (agent-safe)
+
+Push secrets to Cloudflare Workers without exposing values:
+
+```bash
+cd {venture-worker-dir}
+infisical export --format=json --path /{venture} --env prod | npx wrangler secret bulk
+```
+
+No secret values appear in the transcript. If the venture has multiple workers, push to each.
+
+## Step 5: Smoke Test
+
+Run these checks and report pass/fail:
+
+1. **Health endpoint** - `curl` the production health endpoint
+2. **Auth flow** - venture-specific auth check (describe what to test based on the venture's tech stack)
+3. **Sentry** - verify Sentry project exists and is receiving events (if integrated)
+4. **Uptime monitor** - confirm external monitoring is configured
+
+If any fail: "Smoke test failures above. Fix before continuing. Old credentials have NOT been revoked yet."
+
+If all pass, ask via AskUserQuestion:
+
+**Question:** "Smoke tests passed. Revoke old credentials at their source consoles now. Self-generated tokens (like ENCRYPTION_KEY) don't need revocation - rotation was the control."
+
+**Options:**
+
+1. "Old credentials revoked" - proceed to ship
+2. "Cancel" - abort (new credentials remain active, no rollback needed)
+
+## Step 6: Ship
+
+1. Update `config/ventures.json`:
+   - Set `portfolio.status` to `"launched"`
+   - Set `portfolio.url` if provided by user (ask if not already set)
+   - Update `bvmStage` if appropriate
+2. Commit with message: `feat: launch {venture name}`
+3. Create handoff via `crane_handoff` MCP tool with summary of what was launched
+
+Report: "{Venture Name} is live. ventures.json updated, handoff saved."
+
+## Important Notes
+
+- **Transcript cleanup is optional hygiene.** Rotation already invalidated any exposed values. Old transcripts in ~/.claude/ contain dead credentials after rotation.
+- **If smoke tests fail after rotating an immediate-revocation secret** (like OAuth client secrets), the old value is already dead. Fix the issue with the new credential - don't try to rollback.
+- **Shared credentials require coordination.** If GOOGLE_CLIENT_SECRET is rotated for /dc, the old value dies immediately for /ke too. Push to all consuming ventures before revoking.

--- a/.claude/commands/heartbeat.md
+++ b/.claude/commands/heartbeat.md
@@ -1,0 +1,211 @@
+# /heartbeat - Keep Session Alive
+
+Send a heartbeat to prevent your session from timing out.
+
+## What It Does
+
+1. Finds your active session from Context Worker
+2. Updates the `last_heartbeat_at` timestamp
+3. Prevents 45-minute session timeout
+4. Shows when next heartbeat is recommended
+
+## When to Use
+
+- Working on long tasks (>30 minutes)
+- Want to keep session active while reading/researching
+- Need to maintain "active" status visibility
+
+**Not needed if:** You're actively using `/sod`, `/update`, or `/eod` - those all refresh heartbeat automatically.
+
+## Usage
+
+```bash
+/heartbeat
+```
+
+## Execution Steps
+
+### 1. Find Active Session
+
+```bash
+# Get current repo
+REPO=$(git remote get-url origin 2>/dev/null | sed -E 's/.*github\.com[:\/]([^\/]+\/[^\/]+)(\.git)?$/\1/')
+
+if [ -z "$REPO" ]; then
+  echo "❌ Not in a git repository"
+  exit 1
+fi
+
+# Determine venture from repo org
+ORG=$(echo "$REPO" | cut -d'/' -f1)
+case "$ORG" in
+  durganfieldguide) VENTURE="dfg" ;;
+  siliconcrane) VENTURE="sc" ;;
+  venturecrane) VENTURE="vc" ;;
+  *)
+    echo "❌ Unknown venture for org: $ORG"
+    exit 1
+    ;;
+esac
+
+# Check for CRANE_CONTEXT_KEY
+if [ -z "$CRANE_CONTEXT_KEY" ]; then
+  echo "❌ CRANE_CONTEXT_KEY not set"
+  echo ""
+  echo "Export the key:"
+  echo "  export CRANE_CONTEXT_KEY=\"your-key-here\""
+  exit 1
+fi
+
+# Detect CLI client (matches sod-universal.sh logic)
+CLIENT="universal-cli"
+if [ -n "$GEMINI_CLI_VERSION" ]; then
+  CLIENT="gemini-cli"
+elif [ -n "$CLAUDE_CLI_VERSION" ]; then
+  CLIENT="claude-cli"
+elif [ -n "$CODEX_CLI_VERSION" ]; then
+  CLIENT="codex-cli"
+fi
+AGENT_PREFIX="$CLIENT-$(hostname)"
+
+# Query Context Worker for active sessions
+ACTIVE_SESSIONS=$(curl -sS "https://crane-context.automation-ab6.workers.dev/active?agent=$AGENT_PREFIX&venture=$VENTURE&repo=$REPO" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY")
+
+# Extract session ID for this agent
+SESSION_ID=$(echo "$ACTIVE_SESSIONS" | jq -r --arg agent "$AGENT_PREFIX" \
+  '.sessions[] | select(.agent | startswith($agent)) | .id' | head -1)
+
+if [ -z "$SESSION_ID" ]; then
+  echo "❌ No active session found"
+  echo ""
+  echo "Run /sod first to start a session"
+  exit 1
+fi
+```
+
+### 2. Send Heartbeat
+
+```bash
+# Build request body
+REQUEST_BODY=$(jq -n \
+  --arg session_id "$SESSION_ID" \
+  '{
+    session_id: $session_id
+  }')
+
+# Call API
+RESPONSE=$(curl -sS "https://crane-context.automation-ab6.workers.dev/heartbeat" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "$REQUEST_BODY")
+
+# Check for errors
+ERROR=$(echo "$RESPONSE" | jq -r '.error // empty')
+if [ -n "$ERROR" ]; then
+  echo "❌ Heartbeat failed"
+  echo ""
+  echo "Error: $ERROR"
+  exit 1
+fi
+```
+
+### 3. Display Results
+
+```bash
+LAST_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.last_heartbeat_at')
+NEXT_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.next_heartbeat_at')
+INTERVAL=$(echo "$RESPONSE" | jq -r '.heartbeat_interval_seconds')
+
+# Convert to human readable
+MINUTES=$((INTERVAL / 60))
+
+echo "💓 Heartbeat sent"
+echo ""
+echo "Session: $SESSION_ID"
+echo "Last heartbeat: $LAST_HEARTBEAT"
+echo "Next heartbeat in: ~$MINUTES minutes"
+echo ""
+echo "Your session will stay active for 45 minutes from this heartbeat."
+```
+
+## Example Output
+
+```bash
+$ /heartbeat
+
+💓 Heartbeat sent
+
+Session: sess_01KF9E64QXARSWVT45Q5ZJXM7H
+Last heartbeat: 2026-01-19T15:00:00Z
+Next heartbeat in: ~11 minutes
+
+Your session will stay active for 45 minutes from this heartbeat.
+```
+
+## Heartbeat Schedule
+
+**Automatic heartbeats happen when you:**
+
+- Run `/sod` (creates/resumes session)
+- Run `/update` (updates branch/commit)
+- Run `/eod` (ends session)
+
+**Manual heartbeat needed when:**
+
+- Working for >30 minutes without above commands
+- Reading docs, planning, researching
+- Want to keep "active" status visible to team
+
+**Recommended interval:** Every 10-15 minutes during long tasks
+
+## Session Timeout
+
+Sessions become "abandoned" after **45 minutes** without heartbeat.
+
+**What happens on timeout:**
+
+- Session marked as "abandoned" (not deleted)
+- Next `/sod` creates new session
+- Old handoffs still available
+
+**To prevent timeout:**
+
+- Run `/heartbeat` every 10-15 minutes
+- Or any command that updates Context Worker
+
+## Notes
+
+- Requires active session (run `/sod` first)
+- Requires CRANE_CONTEXT_KEY environment variable
+- No-op if session already recently updated
+- Safe to call frequently (idempotent)
+
+## Error Handling
+
+**No active session:**
+
+```
+❌ No active session found
+
+Run /sod first to start a session
+```
+
+**Session ended:**
+
+```
+❌ Heartbeat failed
+
+Error: Session is not active
+```
+
+**Session timeout (>45 min):**
+
+```
+❌ Heartbeat failed
+
+Error: Session not found
+```
+
+(Session was marked abandoned - run `/sod` to start new one)

--- a/.claude/commands/prd-review.md
+++ b/.claude/commands/prd-review.md
@@ -1,0 +1,639 @@
+# /prd-review - Multi-Agent PRD Review
+
+This command orchestrates a 6-agent PRD review process with configurable rounds. It reads existing source documents, runs structured critique rounds with parallel agents, and synthesizes the output into a production-ready PRD.
+
+Works in any venture console that has the required source documents.
+
+## Arguments
+
+```
+/prd-review [rounds]
+```
+
+- `rounds` - number of review rounds (default: **1**). Each additional round adds cross-pollination where agents read and respond to each other's work.
+  - **1 round**: Independent analysis + synthesis. Fast. Good for early-stage products or first PRD drafts.
+  - **2 rounds**: Adds cross-pollination. Agents revise after reading all Round 1 output.
+  - **3 rounds**: Full process. Adds final polish round with unresolved issues. Best for mature products heading into development.
+
+Parse the argument: if `$ARGUMENTS` is empty or not a number, default to 1. If it's a number, use that value. There is no upper bound - if someone wants 5 rounds, run 5 rounds.
+
+Store as `TOTAL_ROUNDS`.
+
+## Execution
+
+### Step 1: Locate Source Documents
+
+Search for source material in three places, in priority order:
+
+**1. Local filesystem (primary)**
+
+Glob for input files. Names vary across ventures:
+
+```
+docs/process/*project-instructions*
+docs/process/*project-description*
+docs/pm/*.md (exclude prd-contributions/ subdirectory and prd.md itself)
+```
+
+**2. crane-context API (fallback)**
+
+If local files are missing, try pulling from crane-context. Determine the venture code from the repo name (e.g., `ke-console` → `ke`, `dc-console` → `dc`). Then use the crane MCP tools or curl:
+
+```bash
+# List available docs for this venture
+curl -s -H "X-Relay-Key: $CRANE_CONTEXT_KEY" \
+  "https://crane-context.automation-ab6.workers.dev/docs?venture={VENTURE_CODE}"
+
+# Fetch a specific doc (e.g., project instructions)
+curl -s -H "X-Relay-Key: $CRANE_CONTEXT_KEY" \
+  "https://crane-context.automation-ab6.workers.dev/docs/{VENTURE_CODE}/{doc_name}"
+```
+
+Look for docs matching `*project-instructions*` or `*project-description*` in the venture's scope. If found, download the content and use it as source material. Also check for any PRD or product spec documents.
+
+**3. Classify what you found**
+
+You need **at minimum one** source document to proceed. Ideally two categories:
+
+1. **Project instructions/description** - the foundational product vision, tech stack, principles, and constraints
+2. **PRD or product spec** - the current PRD draft or product spec
+
+**If you found both:** Proceed normally.
+
+**If you found only one (e.g., just a PRD or just project instructions):** Proceed with what you have. Note to the user which category is missing and that the review will work from a single source. The agents will still produce useful output - the review just won't have the benefit of cross-referencing two distinct documents.
+
+**If you found nothing (no local files AND crane-context has no docs for this venture):** Stop and tell the user:
+
+> I couldn't find any source documents - not locally and not in crane-context.
+>
+> This command needs at least one of:
+>
+> 1. **Project instructions** at `docs/process/{venture}-project-instructions.md`
+> 2. **PRD** at `docs/pm/prd.md` (or similar)
+>
+> Create at least one of these files, then re-run `/prd-review`.
+>
+> Tip: Check if your venture has docs in crane-context that haven't been synced locally:
+> `curl -s -H "X-Relay-Key: $CRANE_CONTEXT_KEY" "https://crane-context.automation-ab6.workers.dev/docs?venture={venture-code}"`
+
+### Step 2: Extract and Confirm Venture Context
+
+Read all source documents found in Step 1. Extract the following into a confirmation table:
+
+| Field                 | Value                             |
+| --------------------- | --------------------------------- |
+| Product Name          | _(from docs)_                     |
+| Tagline / One-liner   | _(from docs)_                     |
+| Tech Stack            | _(from docs)_                     |
+| Target User           | _(from docs)_                     |
+| Primary Platform      | _(from docs)_                     |
+| MVP Features (count)  | _(from docs)_                     |
+| Kill Criteria         | _(from docs, or "Not specified")_ |
+| Competitors Mentioned | _(from docs, or "None")_          |
+
+Also display: **"Running {TOTAL_ROUNDS} round(s) with 6 agents."**
+
+Present the table and ask the user: **"Does this look right? Anything to correct before I start the review?"**
+
+Wait for confirmation. If user provides corrections, note them - they become additional context for all agents.
+
+### Step 3: Handle Previous Runs
+
+Check if `docs/pm/prd-contributions/` exists.
+
+If it does:
+
+1. Create archive directory: `docs/pm/prd-contributions-archive/` (if it doesn't exist)
+2. Move the entire `docs/pm/prd-contributions/` directory to `docs/pm/prd-contributions-archive/{ISO-date}/` where `{ISO-date}` is today's date (e.g., `2026-02-06`)
+3. Tell the user: "Archived previous run to `docs/pm/prd-contributions-archive/{ISO-date}/`"
+
+If the archive date directory already exists (second run same day), append a counter: `{ISO-date}-2`, `{ISO-date}-3`, etc.
+
+### Step 4: Create Context File and Directory Structure
+
+**First**, write the context file that all agents will read. This MUST be created before any round directories or agent launches:
+
+Write `docs/pm/prd-contributions/context.md`:
+
+```markdown
+# PRD Review Context
+
+## Source Documents
+
+- {absolute_path_to_source_doc_1}
+- {absolute_path_to_source_doc_2}
+
+## User Corrections
+
+{verbatim corrections from Step 2, or "None"}
+
+## Review Parameters
+
+- Rounds: {TOTAL_ROUNDS}
+- Date: {TODAY}
+```
+
+List every source document found in Step 1 by its absolute file path. If corrections were provided in Step 2, include them verbatim.
+
+**Then** create round directories for each round that will be run:
+
+```bash
+for N in 1..TOTAL_ROUNDS:
+  mkdir -p docs/pm/prd-contributions/round-{N}
+```
+
+### Step 5: Run Review Rounds
+
+Execute `TOTAL_ROUNDS` rounds sequentially. For each round N (from 1 to TOTAL_ROUNDS):
+
+---
+
+**If N == 1 (first round - always independent analysis):**
+
+Launch **6 parallel agents** in a single message using the Task tool (`subagent_type: general-purpose`).
+
+**CRITICAL**: All 6 Task tool calls MUST be in a single message to run in true parallel.
+
+**Do NOT read source documents or embed their contents in the prompt.** Agents have full tool access and will read files themselves.
+
+Each agent receives:
+
+- The path to the context file
+- Their role brief (from Role Definitions below)
+- Output path: `docs/pm/prd-contributions/round-1/{role-slug}.md`
+
+Agent prompt template for Round 1:
+
+```
+You are the {ROLE_NAME} on a PRD review panel. Your job is to analyze the source documents and write a comprehensive contribution from your role's perspective.
+
+## Instructions
+
+1. Read the review context file at: docs/pm/prd-contributions/context.md
+2. Read each source document listed in the context file.
+3. If user corrections are noted in the context file, treat them as binding amendments to the source documents.
+4. Write your contribution to: {OUTPUT_PATH}
+
+## Your Role
+
+{ROLE_BRIEF}
+
+## Output Requirements
+
+- Write your contribution as a single markdown file
+- Start with a header: `# {ROLE_NAME} Contribution - PRD Review Round 1`
+- Include metadata: Author, Date ({TODAY}), Scope (MVP/Phase 0 only)
+- Use `##` for major sections, `###` for subsections
+- Be specific and concrete - no hand-waving
+- Reference specific features, metrics, and constraints from the source documents
+- Project instructions override the PRD where they conflict. MVP scope only.
+
+Write the file to: {OUTPUT_PATH}
+```
+
+Wait for all 6 agents to complete before proceeding.
+
+**Between-round validation:** Use Glob to find all `.md` files in `docs/pm/prd-contributions/round-1/`. Verify 6 files exist. If fewer than 6, warn the user which roles are missing and ask whether to proceed or retry the failed agents.
+
+Tell the user: **"Round 1 complete. All 6 agents have written their independent analyses."**
+
+---
+
+**If N > 1 and N < TOTAL_ROUNDS (middle round - cross-pollination):**
+
+**Do NOT read prior-round contribution files.** Agents will read them directly from disk.
+
+Launch **6 parallel agents** in a single message.
+
+Each agent receives:
+
+- The path to the context file
+- The prior round number to read contributions from
+- Their role brief
+- Output path: `docs/pm/prd-contributions/round-{N}/{role-slug}.md`
+
+Agent prompt template for middle rounds:
+
+```
+You are the {ROLE_NAME} on a PRD review panel. This is Round {N}. You will read all Round {N-1} contributions from all 6 roles and revise your contribution based on what you've learned.
+
+## Instructions
+
+1. Read the review context file at: docs/pm/prd-contributions/context.md
+2. Read each source document listed in the context file.
+3. If user corrections are noted in the context file, treat them as binding amendments.
+4. Use the Glob tool to find all .md files in docs/pm/prd-contributions/round-{N-1}/.
+   Read every file found. These are the prior round contributions from all roles.
+   If fewer than 6 files exist, note which roles are missing in your output.
+5. Write your revised contribution to: {OUTPUT_PATH}
+
+## Your Role
+
+{ROLE_BRIEF}
+
+## Round {N} Requirements
+
+- Start with `# {ROLE_NAME} Contribution - PRD Review Round {N}`
+- Include metadata: Author, Date ({TODAY}), Scope (MVP/Phase 0 only), Status: Revised after cross-role review
+- Your FIRST section after metadata MUST be `## Changes from Round {N-1}` with a numbered list of key revisions. For each: what changed, why, which role's input triggered it.
+- Then write your full revised contribution (not just a diff - the complete document)
+- Resolve contradictions you see between roles
+- Fill gaps identified by other roles
+- Cross-reference other roles: "The Technical Lead specified...", "The Target Customer said..."
+- Ground abstract principles in concrete implementation
+- Project instructions override the PRD where they conflict. MVP scope only.
+
+Write the file to: {OUTPUT_PATH}
+```
+
+Wait for all 6 agents to complete.
+
+**Between-round validation:** Use Glob to find all `.md` files in `docs/pm/prd-contributions/round-{N}/`. Verify 6 files exist. If fewer than 6, warn the user which roles are missing and ask whether to proceed or retry the failed agents.
+
+Tell the user: **"Round {N} complete. All 6 agents have revised based on cross-role input."**
+
+---
+
+**If N == TOTAL_ROUNDS and N > 1 (final round - polish + unresolved issues):**
+
+**Do NOT read prior-round contribution files.** Agents will read them directly from disk.
+
+Launch **6 parallel agents** in a single message.
+
+Each agent receives:
+
+- The path to the context file
+- The prior round number to read contributions from
+- Their role brief
+- Output path: `docs/pm/prd-contributions/round-{N}/{role-slug}.md`
+
+Agent prompt template for the final round:
+
+```
+You are the {ROLE_NAME} on a PRD review panel. This is Round {N} (FINAL). You will read all Round {N-1} contributions and write your final, polished contribution.
+
+## Instructions
+
+1. Read the review context file at: docs/pm/prd-contributions/context.md
+2. Read each source document listed in the context file.
+3. If user corrections are noted in the context file, treat them as binding amendments.
+4. Use the Glob tool to find all .md files in docs/pm/prd-contributions/round-{N-1}/.
+   Read every file found. These are the prior round contributions from all roles.
+   If fewer than 6 files exist, note which roles are missing in your output.
+5. Write your final contribution to: {OUTPUT_PATH}
+
+## Your Role
+
+{ROLE_BRIEF}
+
+## Round {N} (Final) Requirements
+
+- Start with `# {ROLE_NAME} Contribution - PRD Review Round {N} (Final)`
+- Include metadata: Author, Date ({TODAY}), Scope (MVP/Phase 0 only), Status: Final after {N} rounds
+- Your FIRST section after metadata MUST be `## Changes from Round {N-1}` with a numbered list of key revisions.
+- Write your full final contribution (complete document, not a diff)
+- Standardize terminology across your document to match consensus from other roles
+- Your LAST section MUST be `## Unresolved Issues` - list genuine disagreements that need a human decision. For each:
+  - **The disagreement**: what each role says
+  - **Why it matters**: impact on the product
+  - **My position**: your stance as this role
+  - **Needs**: what type of decision is required (PM call, ADR, user research, etc.)
+- If there are no unresolved issues from your perspective, state that explicitly
+- Project instructions override the PRD where they conflict. MVP scope only.
+
+Write the file to: {OUTPUT_PATH}
+```
+
+Wait for all 6 agents to complete.
+
+**Between-round validation:** Use Glob to find all `.md` files in `docs/pm/prd-contributions/round-{N}/`. Verify 6 files exist. If fewer than 6, warn the user which roles are missing and ask whether to proceed with synthesis or retry the failed agents.
+
+Tell the user: **"Round {N} (final) complete. All contribution files are written. Starting synthesis."**
+
+---
+
+**Special case: TOTAL_ROUNDS == 1**
+
+When only 1 round is run, Round 1 IS the final round. The Round 1 prompt template is used as-is (no "Changes from" or "Unresolved Issues" sections since there's nothing to compare against). Proceed directly to synthesis.
+
+Tell the user: **"Round 1 complete. All 6 agents have written their analyses. Starting synthesis."**
+
+### Step 6: Synthesis
+
+**Pre-synthesis validation:** Use Glob to find all `.md` files in `docs/pm/prd-contributions/round-{TOTAL_ROUNDS}/`. Verify 6 files exist. If fewer than 6, warn the user with which roles are missing and ask whether to proceed with synthesis or retry the failed agents.
+
+**Do NOT read the contribution files.** Launch a dedicated synthesis subagent that reads them directly from disk.
+
+Launch **1 agent** using the Task tool (`subagent_type: general-purpose`) with this prompt:
+
+```
+You are the PRD Synthesis Agent. Your job is to read all final-round contributions from a 6-role PRD review panel and synthesize them into a single, unified PRD.
+
+## Instructions
+
+1. Read the review context file at: docs/pm/prd-contributions/context.md
+2. Read each source document listed in the context file (for reference on product name, tech stack, etc.).
+3. Use the Glob tool to find all .md files in docs/pm/prd-contributions/round-{TOTAL_ROUNDS}/.
+   Read every file found. These are the final contributions from all roles.
+4. Synthesize all contributions into a single PRD and write it to: docs/pm/prd.md
+
+## PRD Structure
+
+Write the synthesized PRD following this exact structure:
+
+# {Product Name} - Product Requirements Document
+
+> Synthesized from {TOTAL_ROUNDS}-round, 6-role PRD review process. Generated {TODAY}.
+
+## Table of Contents
+
+1. Executive Summary
+2. Product Vision & Identity
+3. Target Users & Personas
+4. Core Problem
+5. Product Principles
+6. Competitive Positioning
+7. MVP User Journey
+8. MVP Feature Specifications
+9. Information Architecture
+10. Architecture & Technical Design
+11. Proposed Data Model
+12. API Surface
+13. Non-Functional Requirements
+14. Platform-Specific Design Constraints
+15. Success Metrics & Kill Criteria
+16. Risks & Mitigations
+17. Open Decisions / ADRs
+18. Phased Development Plan
+19. Glossary
+    Appendix: Unresolved Issues
+
+## Synthesis Rules - Section-to-Role Mapping
+
+| Section                                  | Primary Source                  | Supporting Sources                |
+| ---------------------------------------- | ------------------------------- | --------------------------------- |
+| 1. Executive Summary                     | Product Manager                 | All                               |
+| 2. Product Vision & Identity             | Product Manager                 | Target Customer                   |
+| 3. Target Users & Personas               | UX Lead                         | Target Customer                   |
+| 4. Core Problem                          | Target Customer                 | UX Lead                           |
+| 5. Product Principles                    | Product Manager                 | All                               |
+| 6. Competitive Positioning               | Competitor Analyst              | Product Manager                   |
+| 7. MVP User Journey                      | UX Lead                         | Target Customer, Business Analyst |
+| 8. MVP Feature Specifications            | Business Analyst                | Product Manager, Technical Lead   |
+| 9. Information Architecture              | UX Lead                         | Technical Lead                    |
+| 10. Architecture & Technical Design      | Technical Lead                  | Product Manager                   |
+| 11. Proposed Data Model                  | Technical Lead                  | Business Analyst                  |
+| 12. API Surface                          | Technical Lead                  | Business Analyst                  |
+| 13. Non-Functional Requirements          | Technical Lead                  | Product Manager                   |
+| 14. Platform-Specific Design Constraints | UX Lead                         | Technical Lead                    |
+| 15. Success Metrics & Kill Criteria      | Product Manager                 | Business Analyst                  |
+| 16. Risks & Mitigations                  | Product Manager, Technical Lead | All                               |
+| 17. Open Decisions / ADRs               | Product Manager, Technical Lead | All                               |
+| 18. Phased Development Plan              | Product Manager                 | Technical Lead                    |
+| 19. Glossary                             | Business Analyst                | All                               |
+| Appendix: Unresolved Issues              | All                             | -                                 |
+
+## Synthesis Guidelines
+
+- The synthesized PRD should read as a unified document, not a collage
+- PM's voice is primary for vision/strategy sections
+- Technical Lead is authoritative for architecture sections
+- Preserve concrete artifacts: SQL schemas, API specs, user stories, acceptance criteria
+- Include the Target Customer's voice as quoted validation where relevant
+- The Unresolved Issues appendix collects ALL unresolved items from all final-round contributions, deduplicated. If only 1 round was run, this appendix may be minimal or empty - that's fine.
+- This file overwrites any existing docs/pm/prd.md (the contributions are the audit trail)
+
+## Output
+
+Write the complete synthesized PRD to: docs/pm/prd.md
+
+After writing, include a brief metadata line at the end of the file as an HTML comment:
+<!-- Synthesis: {section_count} sections, {word_count} words, {unresolved_count} unresolved issues, {TOTAL_ROUNDS} rounds -->
+```
+
+Wait for the synthesis agent to complete.
+
+**Post-synthesis validation:** Use Glob to verify `docs/pm/prd.md` exists. Read the first 20 lines to confirm the document header is well-formed.
+
+Tell the user: **"Synthesis complete. PRD written to `docs/pm/prd.md`."**
+
+Provide a brief summary: section count, word count, number of unresolved issues flagged, number of rounds run. (Extract from the metadata comment at the end of the file.)
+
+### Step 7: Backlog Creation (Optional)
+
+Ask the user: **"Would you like me to create GitHub issues from this PRD?"**
+
+If yes:
+
+1. Parse the PRD for actionable items: user stories, technical tasks, ADRs to write
+2. Group into logical issues
+3. Present the proposed issue list for approval
+4. Create via `gh issue create` with appropriate labels
+
+If no, finish with: **"PRD review complete. {TOTAL_ROUNDS \* 6} contribution files in `docs/pm/prd-contributions/`, synthesized PRD at `docs/pm/prd.md`."**
+
+---
+
+## Role Definitions
+
+### Product Manager
+
+```
+You are the Product Manager. You own the product vision, strategic framing, and phased roadmap.
+
+YOUR SECTIONS:
+- Executive Summary: crisp problem→solution→value statement
+- Product Vision & Identity: name, tagline, positioning, what this is NOT
+- Product Principles: 5-7 prioritized principles that guide tradeoff decisions
+- Success Metrics & Kill Criteria: quantified targets that determine if MVP succeeds or gets killed
+- Risks & Mitigations: business, market, and execution risks with concrete mitigations
+- Open Decisions / ADRs: decisions that need to be made before or during development
+- Phased Development Plan: what's in MVP, what's Phase 1, what's deferred
+
+CONSTRAINTS:
+- Project instructions override the PRD where they conflict
+- MVP scope only - do not expand scope beyond what source documents define
+- Kill criteria must be specific and measurable (not "good user engagement")
+- Every risk needs a mitigation, not just identification
+- Phases must have clear boundaries - a feature is in one phase, not "partially in Phase 0"
+
+OUTPUT FORMAT:
+- Markdown with ## section headers
+- Tables for metrics and criteria
+- Numbered lists for principles and phases
+- Be decisive - state positions, don't hedge
+```
+
+### Technical Lead
+
+```
+You are the Technical Lead. You own architecture, data model, API design, and non-functional requirements.
+
+YOUR SECTIONS:
+- Architecture & Technical Design: system boundaries, layers, key design decisions
+- Proposed Data Model: table schemas with columns, types, constraints, and relationships
+- API Surface: every endpoint with method, path, request/response shape, auth requirements
+- Non-Functional Requirements: performance budgets, security requirements, scalability targets
+- Technical Risks: implementation risks with severity and mitigations
+- Open Decisions / ADRs: technical decisions that need formal recording
+
+CONSTRAINTS:
+- Project instructions override the PRD where they conflict
+- The tech stack is decided - do not propose alternatives to what's in the source documents
+- MVP scope only
+- Data model must use actual SQL-style definitions, not prose descriptions
+- API endpoints must be concrete (HTTP method + path + shape), not abstract
+- NFRs must have numbers (response time < Xms, not "fast")
+- Architecture diagrams use ASCII art or structured text, not references to external tools
+
+OUTPUT FORMAT:
+- Markdown with ## section headers
+- Code blocks for schemas, API specs, and architecture diagrams
+- Tables for NFR budgets and risk matrices
+- Be precise - ambiguity in technical specs causes bugs
+```
+
+### Business Analyst
+
+```
+You are the Business Analyst. You own user stories, acceptance criteria, business rules, and traceability.
+
+YOUR SECTIONS:
+- MVP User Stories: numbered (US-001, US-002, etc.) with persona, narrative, and acceptance criteria
+- Acceptance Criteria: Given/When/Then format, every criterion must be testable
+- Business Rules: explicit rules governing product behavior
+- Edge Cases: what happens at boundaries and in error states
+- Traceability Matrix: mapping stories to features to success metrics
+
+CONSTRAINTS:
+- Project instructions override the PRD where they conflict
+- MVP scope only
+- Every user story needs: title, persona, narrative ("As a... I want... So that..."), acceptance criteria, business rules, and out-of-scope notes
+- Acceptance criteria must be binary pass/fail - no subjective criteria
+- Business rules must be unambiguous - if there's a judgment call, flag it as an open question
+- Number everything for cross-referencing (US-XXX, BR-XXX, OQ-XXX)
+
+OUTPUT FORMAT:
+- Markdown with ## section headers
+- Checkbox lists for acceptance criteria
+- Tables for traceability matrix
+- Be exhaustive - missed edge cases become production bugs
+```
+
+### UX Lead
+
+```
+You are the UX Lead. You own personas, user journey, information architecture, and interaction design.
+
+YOUR SECTIONS:
+- Target User Personas: detailed narrative personas (not demographic bullet points)
+- User Journey: step-by-step MVP flow from first touch to core value delivery
+- Information Architecture: screen inventory, navigation structure, content hierarchy
+- Interaction Patterns: key UI flows with states, transitions, error handling
+- Platform-Specific Design Constraints: constraints for the primary platform (from source docs)
+- Accessibility Requirements: WCAG compliance targets, assistive technology support
+
+CONSTRAINTS:
+- Project instructions override the PRD where they conflict
+- MVP scope only
+- Personas must be narrative (give them names, jobs, frustrations, goals) - not demographic checkboxes
+- User journey must be concrete: screen-by-screen, not abstract
+- Information architecture = actual screen list with content blocks, not vague categories
+- Design for the primary platform first (from source docs), note adaptations for others
+- Accessibility is not optional - include specific WCAG targets
+
+OUTPUT FORMAT:
+- Markdown with ## section headers
+- Narrative prose for personas and journey
+- Structured lists for IA and interaction patterns
+- Be specific - "a settings screen" is not enough; list what's on it
+```
+
+### Target Customer
+
+```
+You are the Target Customer - the actual person this product is being built for. Stay in character throughout.
+
+Write in FIRST PERSON. You are not an analyst - you are the user. React to this product as a real person would.
+
+YOUR SECTIONS:
+- Who I Am: brief intro establishing your identity, job, daily frustrations
+- My Current Pain: what you do today without this product (be specific and emotional)
+- First Reactions: what excites you, what confuses you, what scares you about this product
+- Feature Reactions: go through each MVP feature - would you use it? Why or why not?
+- What I Need to See: what would make you try this on day one
+- Make-or-Break Concerns: what would make you abandon this product
+- Willingness to Pay: honest assessment of pricing sensitivity
+
+CONSTRAINTS:
+- Project instructions override the PRD where they conflict
+- Stay in character as the target user described in the source documents
+- Be honest, not polite - if something is confusing, say so
+- If a feature sounds like it was designed by engineers for engineers, call it out
+- React to WHAT'S DESCRIBED, not what you wish existed
+- Express genuine emotion: frustration, excitement, skepticism, confusion
+- You are not a product person - don't use product jargon
+
+OUTPUT FORMAT:
+- First-person narrative prose
+- Conversational tone - this reads like a user interview transcript, not a report
+- Use "I" and "my" throughout
+- Bold or emphasize strong reactions
+- Be blunt
+```
+
+### Competitor Analyst
+
+```
+You are the Competitor Analyst. You provide honest, research-backed competitive intelligence.
+
+YOUR SECTIONS:
+- Competitive Landscape: map of direct and indirect competitors
+- Competitor Deep Dives: for each major competitor - pricing, target user, strengths, weaknesses, platform, threat level
+- Feature Comparison Matrix: table comparing MVP features across competitors
+- Differentiation Analysis: where this product genuinely differs (and where it doesn't)
+- Pricing & Business Model Benchmarks: what competitors charge, what users expect to pay
+- Uncomfortable Truths: honest assessment of competitive weaknesses and risks
+
+CONSTRAINTS:
+- Project instructions override the PRD where they conflict
+- Use web search (WebSearch tool) for current competitor data - don't rely on stale knowledge
+- Be honest about where competitors are stronger
+- "Uncomfortable truths" section is mandatory - every product has competitive weaknesses
+- Don't invent differentiation that doesn't exist
+- Pricing analysis must reference actual competitor pricing, not guesses
+- Threat level assessment: low/medium/high with justification
+
+OUTPUT FORMAT:
+- Markdown with ## section headers
+- Tables for comparison matrices and pricing
+- Be analytical - this is intelligence, not cheerleading
+- Cite sources where possible (competitor websites, pricing pages, reviews)
+```
+
+---
+
+## Role-to-Slug Mapping
+
+| Role               | Slug (filename)      |
+| ------------------ | -------------------- |
+| Product Manager    | `product-manager`    |
+| Technical Lead     | `technical-lead`     |
+| Business Analyst   | `business-analyst`   |
+| UX Lead            | `ux-lead`            |
+| Target Customer    | `target-customer`    |
+| Competitor Analyst | `competitor-analyst` |
+
+---
+
+## Notes
+
+- **Re-runs are safe**: Previous contributions are archived before a new run starts
+- **Source documents are not modified**: Only `docs/pm/prd.md` is written (overwritten)
+- **Contributions are the audit trail**: `TOTAL_ROUNDS * 6` files show how the PRD evolved
+- **Agent type**: All role agents use `subagent_type: general-purpose` via the Task tool
+- **Parallelism**: Each round launches all 6 agents in a single message for true parallel execution
+- **File-path delegation**: The orchestrator never embeds file contents in agent prompts. Instead, agents receive file paths and use Glob + Read to access inputs directly. This keeps the orchestrator context lightweight regardless of document size or round count.
+- **Between-round validation**: The orchestrator uses Glob to verify expected contribution files exist after each round. It does not read contribution contents - only checks file count.
+- **Large source documents**: If combined prior-round contributions exceed 100KB, agents may need substantial context. Each agent gets a fresh context window, so this scales better than embedding in the orchestrator.
+- **Default is 1 round**: Fast and sufficient for most use cases. Use more rounds when the product is mature and heading into development.

--- a/.claude/commands/sod.md
+++ b/.claude/commands/sod.md
@@ -1,0 +1,119 @@
+# /sod - Start of Day
+
+This command prepares your session using MCP tools to validate context, show work priorities, and ensure you're ready to code.
+
+## Execution
+
+### Step 1: Run Preflight Checks
+
+Call the `crane_preflight` MCP tool to validate environment:
+
+- CRANE_CONTEXT_KEY is set
+- gh CLI is authenticated
+- Git repository detected
+- API connectivity
+
+**If any critical check fails**, show the error and stop. The user needs to fix their environment.
+
+### Step 2: Start Session
+
+Call the `crane_sod` MCP tool to initialize the session.
+
+The tool returns:
+
+- Session context (venture, repo, branch)
+- Last handoff summary
+- P0 issues (if any)
+- Weekly plan status
+- Cadence briefing (overdue/due recurring activities)
+- Active sessions (conflict detection)
+- Enterprise context (executive summaries)
+
+> **Note:** Portfolio review status, code review staleness, and other recurring activity checks are now centralized in the Cadence section (powered by the schedule registry). No separate VCMS queries needed.
+
+> **Note:** The MCP tool reads the weekly plan but does not auto-create it. If the plan is missing, Step 5 below guides you through creating it.
+
+### Step 3: Display Context Confirmation
+
+Present a clear context confirmation box:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  VENTURE:  {venture_name} ({venture_code})                  │
+│  REPO:     {repo}                                           │
+│  BRANCH:   {branch}                                         │
+│  SESSION:  {session_id}                                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+State: "You're in the correct repository and on the {branch} branch."
+
+### Step 4: Handle P0 Issues
+
+If `p0_issues` is not empty:
+
+1. Display prominently with warning icon
+2. Say: "**There are P0 issues that need immediate attention.**"
+3. List each issue
+
+If the P0 lookup failed (e.g., `gh` CLI error), warn: "**Could not check for P0 issues.** Verify `gh auth status` is valid." Continue with the rest of SOD - do not block.
+
+### Step 5: Check Weekly Plan
+
+Based on `weekly_plan.status`:
+
+- **valid**: Note the priority venture and proceed
+- **stale**: Warn user: "Weekly plan is {age_days} days old. Consider updating."
+- **missing**: Ask user:
+  - "What venture is priority this week? (vc/dfg/sc/ke)"
+  - "Any specific issues to target? (optional)"
+  - "Any capacity constraints? (optional)"
+
+  Then create `docs/planning/WEEKLY_PLAN.md`:
+
+  ```markdown
+  # Weekly Plan - Week of {DATE}
+
+  ## Priority Venture
+
+  {venture code}
+
+  ## Target Issues
+
+  {list or "None specified"}
+
+  ## Capacity Notes
+
+  {notes or "Normal capacity"}
+
+  ## Created
+
+  {ISO timestamp}
+  ```
+
+### Step 6: Warn About Active Sessions
+
+If `active_sessions` is not empty:
+
+Display: "**Warning:** Other agents are active on this venture."
+List each session.
+
+### Step 7: STOP and Wait
+
+**CRITICAL**: Do NOT automatically start working.
+
+Present a brief summary and ask: **"What would you like to focus on?"**
+
+If user wants to see the full work queue, call `crane_status` MCP tool.
+
+## Wrong Repo Prevention
+
+All GitHub issues created this session MUST target the repo shown in context confirmation. If you find yourself targeting a different repo, STOP and verify with the user.
+
+## Troubleshooting
+
+If MCP tools aren't available:
+
+1. Check `claude mcp list` shows crane connected
+2. Ensure started with: `crane vc`
+3. Try: `cd ~/dev/crane-console/packages/crane-mcp && npm run build && npm link`

--- a/.claude/commands/sprint.md
+++ b/.claude/commands/sprint.md
@@ -1,0 +1,441 @@
+# /sprint - Parallel Sprint Execution
+
+This command takes a set of pre-selected GitHub issue numbers, builds an optimal wave-based execution plan, and spawns parallel coding agents to implement them simultaneously using git worktrees for isolation.
+
+Works in any venture console repo. The prior step (human or planning agent) selects which issues go into the sprint. This command handles execution.
+
+## Arguments
+
+```
+/sprint <issue numbers> [--dry-run] [--parallel N]
+```
+
+- Issue numbers: space or comma-separated, `#` prefix optional
+- `--dry-run`: show wave plan only, do not execute
+- `--parallel N`: override max concurrent agents (default: machine-based lookup)
+
+Parse `$ARGUMENTS`:
+
+1. Split on whitespace and commas
+2. Strip `#` prefix from any token
+3. Extract `--dry-run` flag if present (remove from list)
+4. Extract `--parallel N` if present (remove both tokens from list)
+5. Remaining tokens are issue numbers (must be positive integers)
+
+If no issue numbers remain after parsing, display usage and stop:
+
+```
+Usage: /sprint <issue numbers> [--dry-run] [--parallel N]
+
+Examples:
+  /sprint 42 45 51              # execute issues 42, 45, 51
+  /sprint 42, 45 --dry-run      # show plan only
+  /sprint 42 45 --parallel 4    # override concurrency limit
+```
+
+Store: `ISSUE_NUMBERS` (array), `DRY_RUN` (bool), `MAX_CONCURRENT` (number or null).
+
+## Execution
+
+### Step 1: Detect Repo and Machine
+
+**Repo context:**
+
+Run these commands to detect context:
+
+```bash
+basename "$(pwd)"          # e.g., ke-console
+git remote get-url origin  # e.g., git@github.com:kidexpenses/ke-console.git
+```
+
+- `VENTURE_CODE`: basename of cwd minus `-console` suffix (e.g., `ke-console` -> `ke`)
+- `REPO`: extract `org/repo` from the git remote URL
+- `REPO_ROOT`: absolute path of the repo root (`git rev-parse --show-toplevel`)
+- `VERIFY_COMMAND`: read the repo's CLAUDE.md and extract the verify command (typically `npm run verify`)
+
+If not in a git repo or can't determine the remote, stop:
+
+```
+Not in a recognized repo. Run /sprint from a venture console directory.
+```
+
+**Machine resources:**
+
+If `--parallel N` was provided, set `MAX_CONCURRENT = N`.
+
+Otherwise, detect hostname:
+
+```bash
+hostname -s
+```
+
+Look up the default:
+
+| Hostname | Max Concurrent |
+| -------- | -------------- |
+| mac23    | 3              |
+| m16      | 3              |
+| mini     | 2              |
+| mbp27    | 2              |
+| think    | 1              |
+| (other)  | 2              |
+
+Display:
+
+```
+Sprint for {REPO}
+Machine: {hostname} | Max concurrent agents: {MAX_CONCURRENT}
+```
+
+### Step 2: Fetch and Analyze Issues
+
+For each issue number in `ISSUE_NUMBERS`, fetch via:
+
+```bash
+gh issue view {N} --repo {REPO} --json number,title,body,labels,state
+```
+
+**CRITICAL**: Make all `gh issue view` calls in parallel (multiple Bash tool calls in one message).
+
+For each issue, extract from labels:
+
+- **Priority**: `prio:*` label (P0/P1/P2/P3)
+- **QA grade**: `qa-grade:*` or `qa:*` label
+- **Component**: `component:*` label
+- **Type**: `type:*` label
+- **Status**: `status:*` label
+
+Also extract from body:
+
+- **AC count**: count checkbox items (`- [ ]` lines)
+- **Body length**: word count of the issue body
+
+**Validation:**
+
+- If any issue does not exist or `gh issue view` fails, stop: `Issue #{N} not found in {REPO}. Aborting.`
+- If any issue has `state: closed`, stop: `Issue #{N} is closed. Remove it and re-run.`
+- If any issue lacks `status:ready`, warn (do not block): `Warning: Issue #{N} has status:{current} instead of status:ready.`
+
+Display issue summary table:
+
+```
+Issues:
+| #   | Title                | Priority | Type  | Component     | Status | ACs | Body Words |
+| --- | -------------------- | -------- | ----- | ------------- | ------ | --- | ---------- |
+| 45  | Fix balance calc     | P0       | bug   | ke-api        | ready  | 4   | 120        |
+| 42  | Add expense filter   | P1       | story | ke-app        | ready  | 6   | 280        |
+| 47  | Update docs          | P2       | tech  | -             | ready  | 2   | 45         |
+```
+
+### Step 3: Build Wave Plan
+
+**Extract explicit dependencies:**
+
+Scan each issue body (case-insensitive) for these patterns:
+
+- `depends on #N`
+- `blocked by #N`
+- `after #N`
+- `requires #N`
+
+Build a dependency graph. Only track dependencies within the sprint issue set. If a dependency references an issue NOT in the sprint, display a warning:
+
+```
+Warning: #{X} depends on #{Y}, which is not in this sprint. Treating as external (resolved).
+```
+
+**Schedule waves:**
+
+```
+available = issues with no unresolved in-sprint deps
+waves = []
+completed = set()
+
+while unscheduled issues remain:
+    wave = []
+    for issue in available (sorted: P0 first, then P1, P2, P3, then by issue number):
+        if len(wave) >= MAX_CONCURRENT: break
+        wave.append(issue)
+    waves.append(wave)
+    completed.update(wave issues)
+    recompute available (deps satisfied by completed set, not already scheduled)
+```
+
+If a cycle is detected (no available issues but unscheduled remain), stop:
+
+```
+Dependency cycle detected among issues: #{A}, #{B}, #{C}. Fix issue dependencies and re-run.
+```
+
+**Advisory warnings:**
+
+If two issues in the same wave share a `component:*` label, display:
+
+```
+Warning: Issues #{X} and #{Y} share component:{name} - may have file conflicts. Merge in listed order.
+```
+
+**Display the full wave plan:**
+
+```
+Wave Plan:
+
+Wave 1 (execute now):
+  #{45} [P0] Fix balance calc - component:ke-api
+  #{42} [P1] Add expense filter - component:ke-app
+  #{47} [P2] Update docs - (no component)
+
+Wave 2 (next run, after merging Wave 1):
+  #{48} [P1] Refactor auth - component:ke-api (depends on #45)
+
+Note: Wave 2 depends on Wave 1. Merge Wave 1 PRs before re-running.
+```
+
+If there is only one wave, omit the "next run" note.
+
+**If `DRY_RUN` is true: stop here.** Display "Dry run complete. Re-run without --dry-run to execute."
+
+### Step 4: Approval
+
+Ask the user using AskUserQuestion:
+
+**"Execute Wave 1? ({N} agents will be spawned)"**
+
+Options: "Execute" / "Abort"
+
+If Abort, stop: "Sprint aborted. Re-run with adjusted arguments."
+
+### Step 5: Set Up Worktrees
+
+**Check for active sprint:**
+
+```bash
+cat {REPO_ROOT}/.worktrees/.sprint.lock 2>/dev/null
+```
+
+If the lock file exists, read the PID from it. Check if the process is alive:
+
+```bash
+kill -0 {PID} 2>/dev/null
+```
+
+- If alive: stop with `Another sprint is active (PID {PID}). Wait for it to finish or kill that process first.`
+- If dead (stale lock): warn `Stale sprint lock found (PID {PID} is dead). Cleaning up and proceeding.` Remove the lock and any leftover worktrees.
+
+**Create lock:**
+
+```bash
+mkdir -p {REPO_ROOT}/.worktrees
+echo "$$" > {REPO_ROOT}/.worktrees/.sprint.lock
+```
+
+**Add `.worktrees/` to `.gitignore`** if not already present:
+
+Check if `.worktrees/` or `.worktrees` appears in `{REPO_ROOT}/.gitignore`. If not, append it:
+
+```bash
+echo '.worktrees/' >> {REPO_ROOT}/.gitignore
+```
+
+**Create worktrees** for each Wave 1 issue:
+
+Branch naming: `{issue-number}-{slugified-title}` where slugified-title is the issue title lowercased, spaces replaced with hyphens, non-alphanumeric characters (except hyphens) removed, truncated to 50 chars, trailing hyphens stripped.
+
+For each issue:
+
+```bash
+git worktree add {REPO_ROOT}/.worktrees/{issue-number} -b {branch-name}
+```
+
+If the branch already exists, ask the user: reuse the existing branch or create with a `-2` suffix.
+
+If the worktree path already exists, remove it first:
+
+```bash
+git worktree remove --force {REPO_ROOT}/.worktrees/{issue-number} 2>/dev/null
+```
+
+**Install dependencies** in parallel (one Bash call per worktree, all in one message):
+
+```bash
+cd {REPO_ROOT}/.worktrees/{issue-number} && npm ci --prefer-offline 2>&1 | tail -5
+```
+
+Display: `Worktrees ready. Dependencies installed.`
+
+### Step 6: Execute Wave 1
+
+**Spawn all agents in ONE message** using the Task tool (`subagent_type: general-purpose`).
+
+**CRITICAL**: All Task tool calls MUST be in a single message to run in true parallel.
+
+Each agent receives the prompt below, filled with its specific values. Store `ISSUE_BODY` from the earlier fetch.
+
+---
+
+**Coding Agent Prompt:**
+
+```
+You are a coding agent implementing a single GitHub issue.
+
+## Assignment
+- Issue: #{NUMBER} - {TITLE}
+- Worktree: {WORKTREE_PATH}
+- Branch: {BRANCH_NAME} (already checked out)
+- Repo: {REPO}
+
+## Issue Details
+{FULL_ISSUE_BODY}
+
+## CRITICAL: Working Directory
+
+The Bash tool resets your working directory between every call. You MUST
+prefix every bash command with `cd {WORKTREE_PATH} &&` or use absolute
+paths prefixed with {WORKTREE_PATH}/. Running commands in the wrong
+directory will corrupt other agents' work.
+
+Before your first code change, verify your branch:
+  cd {WORKTREE_PATH} && git branch --show-current
+If you are not on {BRANCH_NAME}, STOP and report an error.
+
+## Workflow
+
+1. Read {WORKTREE_PATH}/CLAUDE.md for project conventions and build commands.
+2. Explore the relevant code. Read nearby files to understand patterns.
+3. Implement the change. Make minimal, focused changes. Do not refactor
+   unrelated code.
+4. Run verification:
+     cd {WORKTREE_PATH} && {VERIFY_COMMAND}
+   Fix failures and re-run. If you cannot pass after 3 attempts, STOP
+   and report the failure. Do NOT open a PR with failing verification.
+5. Stage specific changed files (not git add -A), commit with a
+   conventional message referencing the issue number.
+6. Push: cd {WORKTREE_PATH} && git push -u origin {BRANCH_NAME}
+7. Open PR:
+     cd {WORKTREE_PATH} && gh pr create --repo {REPO} --base main \
+       --head {BRANCH_NAME} --title "{type}: {description}" \
+       --body "$(cat <<'PREOF'
+   ## Summary
+   {1-2 sentence summary}
+
+   ## Changes
+   - {change 1}
+   - {change 2}
+
+   ## Test Plan
+   - [ ] {test step 1}
+   - [ ] {test step 2}
+
+   Closes #{NUMBER}
+
+   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+   PREOF
+   )"
+
+## Time Awareness
+Small issues (single file, clear fix): aim for under 10 minutes.
+Medium issues (multi-file feature): aim for under 20 minutes.
+Large issues (cross-cutting change): aim for under 30 minutes.
+If you have been working significantly longer than expected, STOP, report
+your progress and what is blocking you, and let the orchestrator decide.
+
+## Report
+Your final message MUST include exactly one of these lines:
+- PR_URL: https://github.com/{repo}/pull/{N}
+- FAILED: {reason}
+
+Also include:
+- FILES_CHANGED: {comma-separated list}
+- VERIFY_STATUS: pass OR fail
+- DECISIONS: {any ambiguity resolutions, or "none"}
+
+## Constraints
+- NEVER run commands outside your worktree
+- NEVER push to main or merge the PR
+- NEVER modify files that are not relevant to your issue
+- If blocked, stop and report immediately with FAILED
+```
+
+---
+
+**After all agents complete:**
+
+Parse each agent's final message:
+
+- Look for `PR_URL:` line to extract PR URL
+- Look for `FAILED:` line to detect failure
+- Extract files changed and verification status
+
+**For each successful PR:**
+
+Update the issue label from `status:ready` to `status:review`:
+
+```bash
+gh issue edit {NUMBER} --repo {REPO} --remove-label "status:ready" --add-label "status:review"
+```
+
+**For each failure:**
+
+Ask the user per failed issue using AskUserQuestion:
+
+**"Issue #{N} failed: {reason}. Retry or skip?"**
+
+Options: "Retry" / "Skip"
+
+- **Retry**: Remove the worktree (`git worktree remove --force ...`), recreate fresh from main, reinstall dependencies, and spawn one new agent with the same prompt. After retry completes, process its result (update labels on success, report failure on second failure without further retry).
+- **Skip**: Mark as incomplete, continue.
+
+### Step 7: Report and Cleanup
+
+Display wave results:
+
+```
+Wave 1 Complete: {succeeded}/{total} issues
+
+| #   | Title              | Status  | PR    |
+| --- | ------------------ | ------- | ----- |
+| 45  | Fix balance calc   | SUCCESS | #67   |
+| 42  | Add expense filter | SUCCESS | #68   |
+| 47  | Update docs        | FAILED  | -     |
+```
+
+If there are remaining waves:
+
+```
+Remaining waves: {count} (issues: #{A}, #{B})
+Next: merge the PRs above, then run: /sprint {remaining issue numbers}
+```
+
+If all waves are done:
+
+```
+All sprint issues processed.
+```
+
+**Cleanup:**
+
+Remove worktrees and lock file:
+
+```bash
+git worktree remove --force {REPO_ROOT}/.worktrees/{N}   # for each issue
+rm -f {REPO_ROOT}/.worktrees/.sprint.lock
+rmdir {REPO_ROOT}/.worktrees 2>/dev/null                  # remove dir if empty
+```
+
+Branches are preserved (they back the open PRs).
+
+Done.
+
+---
+
+## Notes
+
+- **Single-wave execution**: Only Wave 1 is executed per run. User merges those PRs, then re-runs for Wave 2. This eliminates inter-wave state management and the dependency-branching problem.
+- **Worktrees inside repo**: `.worktrees/` lives at the repo root and is gitignored. No external directory management needed.
+- **Branches from main**: Every branch starts from current main. PRs are independently reviewable.
+- **Orchestrator owns side effects**: Label updates happen here, not in the coding agents. Agents only push code and open PRs.
+- **Retry semantics**: Failed agents get a fresh worktree from main. One retry max per failed issue. Second failure is final.
+- **Lock file**: Prevents concurrent sprint runs from colliding. PID-based with stale detection.
+- **Agent type**: All coding agents use `subagent_type: general-purpose` via the Task tool.
+- **Parallelism**: All Wave 1 agents launch in a single message for true parallel execution.
+- **No complexity estimation**: Issue metadata (AC count, body length) is displayed for human judgment. No S/M/L/XL heuristics.

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,0 +1,78 @@
+# /status - Show Session Status
+
+Display current session state, tasks, and git status for situational awareness.
+
+## What to Show
+
+### 1. Session Information
+
+Query crane-context for current session (if available):
+
+- Session ID
+- Session age (how long since /sod)
+- Last heartbeat time
+- Venture context
+
+If no session exists, note: "No active session. Run /sod to start."
+
+### 2. Active Tasks
+
+Use TaskList to show current task state:
+
+- Pending tasks (not started)
+- In-progress tasks (being worked on)
+- Recently completed tasks
+
+### 3. Git Status
+
+Show current repository state:
+
+- Current branch
+- Uncommitted changes (staged and unstaged)
+- Commits ahead/behind remote
+
+### 4. Context Summary
+
+- Current working directory
+- Repository name
+- Machine name (hostname)
+
+## Output Format
+
+```
+== Session Status ==
+Session: [ID or "None"]
+Age: [duration or "N/A"]
+Venture: [venture name or "Unknown"]
+
+== Tasks ==
+In Progress: [count]
+  - [task subject]
+Pending: [count]
+  - [task subject]
+Completed (recent): [count]
+
+== Git ==
+Branch: [branch name]
+Changes: [staged] staged, [unstaged] unstaged
+Remote: [ahead/behind status]
+
+== Context ==
+Repo: [repo name]
+Dir: [current directory]
+Machine: [hostname]
+```
+
+## Implementation Steps
+
+1. Check for active session by querying crane-context /session endpoint
+2. Call TaskList to get task state
+3. Run `git status --porcelain` and `git branch -vv` for git info
+4. Get hostname and current directory from environment
+5. Format and display results
+
+## Notes
+
+- This is a read-only status check - it should not modify anything
+- If crane-context is unavailable, show what information is available locally
+- Keep output concise and scannable

--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -1,0 +1,350 @@
+# /update - Update Session Context
+
+Update your session with current branch, commit, and work metadata.
+
+## What It Does
+
+1. Finds your active session from Context Worker
+2. Auto-detects current git branch and commit
+3. Updates session with current work context
+4. Refreshes heartbeat (keeps session alive)
+5. Provides visibility: "Agent X is on branch Y working on issue #123"
+
+## When to Use
+
+- Started working on a new issue
+- Switched branches
+- Made significant progress (checkpoint)
+- Want to update team visibility
+
+**Tip:** Call this when you start work on an issue and after major milestones.
+
+## Usage
+
+```bash
+# Auto-detect branch/commit
+/update
+
+# With issue number
+/update 123
+
+# With custom metadata
+/update --meta '{"issue": 123, "priority": "P0"}'
+```
+
+## Execution Steps
+
+### 1. Find Active Session
+
+```bash
+# Get current repo
+REPO=$(git remote get-url origin 2>/dev/null | sed -E 's/.*github\.com[:\/]([^\/]+\/[^\/]+)(\.git)?$/\1/')
+
+if [ -z "$REPO" ]; then
+  echo "❌ Not in a git repository"
+  exit 1
+fi
+
+# Determine venture from repo org
+ORG=$(echo "$REPO" | cut -d'/' -f1)
+case "$ORG" in
+  durganfieldguide) VENTURE="dfg" ;;
+  siliconcrane) VENTURE="sc" ;;
+  venturecrane) VENTURE="vc" ;;
+  *)
+    echo "❌ Unknown venture for org: $ORG"
+    exit 1
+    ;;
+esac
+
+# Check for CRANE_CONTEXT_KEY
+if [ -z "$CRANE_CONTEXT_KEY" ]; then
+  echo "❌ CRANE_CONTEXT_KEY not set"
+  echo ""
+  echo "Export the key:"
+  echo "  export CRANE_CONTEXT_KEY=\"your-key-here\""
+  exit 1
+fi
+
+# Detect CLI client (matches sod-universal.sh logic)
+CLIENT="universal-cli"
+if [ -n "$GEMINI_CLI_VERSION" ]; then
+  CLIENT="gemini-cli"
+elif [ -n "$CLAUDE_CLI_VERSION" ]; then
+  CLIENT="claude-cli"
+elif [ -n "$CODEX_CLI_VERSION" ]; then
+  CLIENT="codex-cli"
+fi
+AGENT_PREFIX="$CLIENT-$(hostname)"
+
+# Query Context Worker for active sessions
+ACTIVE_SESSIONS=$(curl -sS "https://crane-context.automation-ab6.workers.dev/active?agent=$AGENT_PREFIX&venture=$VENTURE&repo=$REPO" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY")
+
+# Extract session ID for this agent
+SESSION_ID=$(echo "$ACTIVE_SESSIONS" | jq -r --arg agent "$AGENT_PREFIX" \
+  '.sessions[] | select(.agent | startswith($agent)) | .id' | head -1)
+
+if [ -z "$SESSION_ID" ]; then
+  echo "❌ No active session found"
+  echo ""
+  echo "Run /sod first to start a session"
+  exit 1
+fi
+```
+
+### 2. Detect Current Work Context
+
+```bash
+# Get current branch
+BRANCH=$(git branch --show-current 2>/dev/null)
+
+# Get current commit
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null)
+
+# Parse arguments for issue number or metadata
+ISSUE_NUMBER=""
+META_JSON=""
+
+# If first arg is a number, it's an issue
+if [[ "$1" =~ ^[0-9]+$ ]]; then
+  ISSUE_NUMBER="$1"
+  META_JSON=$(jq -n --argjson issue "$ISSUE_NUMBER" '{issue: $issue}')
+fi
+
+# If --meta flag provided, use that
+if [[ "$1" == "--meta" && -n "$2" ]]; then
+  META_JSON="$2"
+fi
+
+echo "## 📝 Updating Session"
+echo ""
+echo "Session: $SESSION_ID"
+echo "Branch: $BRANCH"
+echo "Commit: $COMMIT"
+if [ -n "$ISSUE_NUMBER" ]; then
+  echo "Issue: #$ISSUE_NUMBER"
+fi
+echo ""
+```
+
+### 3. Build Update Request
+
+```bash
+# Build request body with current context
+REQUEST_BODY=$(jq -n \
+  --arg session_id "$SESSION_ID" \
+  --arg branch "$BRANCH" \
+  --arg commit "$COMMIT" \
+  --argjson meta "${META_JSON:-null}" \
+  '{
+    session_id: $session_id,
+    branch: $branch,
+    commit_sha: $commit
+  } + (if $meta != null then {meta: $meta} else {} end)')
+```
+
+### 4. Call Context Worker /update
+
+```bash
+# Call API
+RESPONSE=$(curl -sS "https://crane-context.automation-ab6.workers.dev/update" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "$REQUEST_BODY")
+
+# Check for errors
+ERROR=$(echo "$RESPONSE" | jq -r '.error // empty')
+if [ -n "$ERROR" ]; then
+  echo "❌ Update failed"
+  echo ""
+  echo "Error: $ERROR"
+  exit 1
+fi
+```
+
+### 5. Display Results
+
+```bash
+UPDATED_AT=$(echo "$RESPONSE" | jq -r '.updated_at')
+NEXT_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.next_heartbeat_at')
+INTERVAL=$(echo "$RESPONSE" | jq -r '.heartbeat_interval_seconds')
+
+# Convert to human readable
+MINUTES=$((INTERVAL / 60))
+
+echo "✅ Session updated"
+echo ""
+echo "Updated at: $UPDATED_AT"
+echo "Next heartbeat: ~$MINUTES minutes"
+echo ""
+echo "Your session context is now visible to other agents."
+```
+
+## Example Usage
+
+**Auto-detect everything:**
+
+```bash
+$ /update
+
+## 📝 Updating Session
+
+Session: sess_01KF9E64QXARSWVT45Q5ZJXM7H
+Branch: feature/vertex-ai-integration
+Commit: abc123d
+
+✅ Session updated
+
+Updated at: 2026-01-19T15:00:00Z
+Next heartbeat: ~11 minutes
+
+Your session context is now visible to other agents.
+```
+
+**With issue number:**
+
+```bash
+$ /update 456
+
+## 📝 Updating Session
+
+Session: sess_01KF9E64QXARSWVT45Q5ZJXM7H
+Branch: fix/auth-bug
+Commit: def789a
+Issue: #456
+
+✅ Session updated
+```
+
+**With custom metadata:**
+
+```bash
+$ /update --meta '{"issue": 789, "priority": "P0", "type": "bug"}'
+
+## 📝 Updating Session
+
+Session: sess_01KF9E64QXARSWVT45Q5ZJXM7H
+Branch: hotfix/critical-auth
+Commit: ghi012b
+
+✅ Session updated
+```
+
+## What Gets Updated
+
+**Always updated:**
+
+- `branch` - Current git branch
+- `commit_sha` - Current commit SHA (short)
+- `last_heartbeat_at` - Session heartbeat
+
+**Optional:**
+
+- `meta` - Custom JSON metadata (issue, priority, etc.)
+
+**Not updated:** venture, repo, track (set at session creation)
+
+## Visibility Benefits
+
+**Other agents can see:**
+
+```bash
+$ /sod  # On any agent
+
+### Active Sessions
+
+Agent: claude-code-macbook
+Track: 1
+Branch: feature/vertex-ai-integration
+Issue: #456
+Last active: 2 minutes ago
+```
+
+**Useful for:**
+
+- Coordinating work across multiple agents
+- Avoiding duplicate work
+- Understanding what's in progress
+
+## Workflow Integration
+
+**Recommended pattern:**
+
+```bash
+# Start work on issue
+/sod
+/update 456
+
+# After major checkpoint (e.g., PR created)
+/update
+
+# End of day
+/eod
+```
+
+**Automatic updates happen on:**
+
+- `/sod` - Sets initial context
+- `/eod` - Final update before ending
+
+**Manual updates useful for:**
+
+- Mid-session checkpoints
+- Branch switches
+- Starting new issue
+
+## Notes
+
+- Auto-detects git branch and commit
+- Requires active session (run `/sod` first)
+- Requires CRANE_CONTEXT_KEY environment variable
+- Refreshes heartbeat (prevents timeout)
+- Safe to call frequently
+
+## Error Handling
+
+**Not in git repo:**
+
+```
+❌ Not in a git repository
+```
+
+**No active session:**
+
+```
+❌ No active session found
+
+Run /sod first to start a session
+```
+
+**Invalid metadata:**
+
+```
+❌ Update failed
+
+Error: Invalid meta field (must be valid JSON object)
+```
+
+## Advanced Usage
+
+**Track multiple issues:**
+
+```bash
+/update --meta '{"issues": [123, 456], "sprint": "2026-01-W3"}'
+```
+
+**Add tags:**
+
+```bash
+/update --meta '{"issue": 789, "tags": ["refactor", "performance"]}'
+```
+
+**Custom workflow state:**
+
+```bash
+/update --meta '{"issue": 234, "state": "code-review", "reviewer": "pm-agent"}'
+```
+
+The `meta` field is freeform JSON - use it for whatever context helps your workflow.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(*)",
+      "Read",
+      "Write",
+      "Edit",
+      "WebFetch",
+      "WebSearch",
+      "Skill",
+      "Glob",
+      "Grep",
+      "Task",
+      "NotebookEdit",
+      "mcp__crane__*",
+      "mcp__apple-notes__*",
+      "mcp__claude_ai_*"
+    ]
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "crane": {
+      "command": "crane-mcp",
+      "args": [],
+      "env": {}
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,12 @@ Venture Crane marketing website (venturecrane.com). Static site built with Astro
 
 ## Session Start
 
-This repo does not currently have Crane MCP integration. Enterprise rules apply manually. See crane-console for the full module system.
+At the start of every session, initialize your context:
+
+1. Call the `crane_preflight` MCP tool (no arguments)
+2. Call the `crane_sod` MCP tool with `venture: "vc"`
+
+Do not start any work until both calls succeed.
 
 ## Enterprise Rules
 
@@ -18,6 +23,20 @@ This repo does not currently have Crane MCP integration. Enterprise rules apply 
 - **Never auto-save to VCMS** without explicit Captain approval.
 - **Scope discipline.** Discover additional work mid-task - finish current scope, file a new issue.
 - **Escalation triggers.** Credential not found in 2 min, same error 3 times, blocked >30 min - stop and escalate.
+
+## Instruction Modules
+
+Detailed domain instructions stored as on-demand documents.
+Fetch the relevant module when working in that domain.
+
+| Module              | Key Rule (always applies)                                                    | Fetch for details                             |
+| ------------------- | ---------------------------------------------------------------------------- | --------------------------------------------- |
+| `secrets.md`        | Verify secret VALUES, not just key existence                                 | Infisical, vault, API keys, GitHub App        |
+| `content-policy.md` | Never auto-save to VCMS; agents ARE the voice                                | VCMS tags, storage rules, editorial, style    |
+| `team-workflow.md`  | All changes through PRs; never push to main                                  | Full workflow, QA grades, escalation triggers |
+| `fleet-ops.md`      | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh | SSH, machines, Tailscale, macOS               |
+
+Fetch with: `crane_doc('global', '<module>')`
 
 ## Build Commands
 


### PR DESCRIPTION
## Summary
- Add `.mcp.json` configuring the crane MCP server for this repo
- Sync 14 shared slash commands from crane-console (excluding global-only commands)
- Add `.claude/settings.json` with MCP permission grants
- Update CLAUDE.md Session Start section with proper `crane_preflight` and `crane_sod` instructions
- Add Instruction Modules section to CLAUDE.md with routing table for on-demand docs

Enterprise Rules section was already present from PR #47 and is preserved unchanged.

Closes venturecrane/crane-console#240

## Test plan
- [ ] Verify `crane_preflight` succeeds when opening a session in this repo
- [ ] Verify `crane_sod` with `venture: "vc"` returns valid context
- [ ] Verify slash commands are available (e.g. `/sod`, `/eod`, `/status`)
- [ ] Verify no duplicate Enterprise Rules in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)