### PR TITLE
fix: correct three evenings to three hours

### DIFF
--- a/src/content/articles/fleet-sprints-ai-agents.md
+++ b/src/content/articles/fleet-sprints-ai-agents.md
@@ -9,7 +9,7 @@ draft: false
 
 Spawning one AI coding agent on a feature branch is straightforward. Spawning ten across four machines, organized into dependency waves, with each agent working an isolated worktree - that is where the failure modes get interesting.
 
-We built a sprint orchestrator that takes a set of GitHub issues, resolves their dependency graph, and executes them in parallel waves using Claude Code agents on git worktrees. A recent feature build was its largest test: 36 PRs across four waves, four machines, three evenings. Most of it went well. The failures revealed specific problems worth documenting.
+We built a sprint orchestrator that takes a set of GitHub issues, resolves their dependency graph, and executes them in parallel waves using Claude Code agents on git worktrees. A recent feature build was its largest test: 36 PRs across four waves, four machines, three hours. Most of it went well. The failures revealed specific problems worth documenting.
 
 ---
 

--- a/src/content/logs/2026-02-20-fleet-sprints-at-scale.md
+++ b/src/content/logs/2026-02-20-fleet-sprints-at-scale.md
@@ -5,7 +5,7 @@ tags: ['shipping']
 draft: false
 ---
 
-The research panel is complete. Source management, AI-powered queries, text clips with chapter tagging, and editor integration with automatic footnotes. The full feature surface went from zero to merged in three evening sessions.
+The research panel is complete. Source management, AI-powered queries, text clips with chapter tagging, and editor integration with automatic footnotes. The full feature surface went from zero to merged in three hours.
 
 ## What Shipped
 


### PR DESCRIPTION
## Summary

- Fixed "three evenings" to "three hours" in both the fleet sprint article and build log

🤖 Generated with [Claude Code](https://claude.com/claude-code)