### PR TITLE
fix: remove QA grading artifacts

### DIFF
--- a/.claude/commands/sprint.md
+++ b/.claude/commands/sprint.md
@@ -100,7 +100,6 @@ gh issue view {N} --repo {REPO} --json number,title,body,labels,state
 For each issue, extract from labels:
 
 - **Priority**: `prio:*` label (P0/P1/P2/P3)
-- **QA grade**: `qa-grade:*` or `qa:*` label
 - **Component**: `component:*` label
 - **Type**: `type:*` label
 - **Status**: `status:*` label

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,12 @@ Do not start any work until both calls succeed.
 Detailed domain instructions stored as on-demand documents.
 Fetch the relevant module when working in that domain.
 
-| Module              | Key Rule (always applies)                                                    | Fetch for details                             |
-| ------------------- | ---------------------------------------------------------------------------- | --------------------------------------------- |
-| `secrets.md`        | Verify secret VALUES, not just key existence                                 | Infisical, vault, API keys, GitHub App        |
-| `content-policy.md` | Never auto-save to VCMS; agents ARE the voice                                | VCMS tags, storage rules, editorial, style    |
-| `team-workflow.md`  | All changes through PRs; never push to main                                  | Full workflow, QA grades, escalation triggers |
-| `fleet-ops.md`      | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh | SSH, machines, Tailscale, macOS               |
+| Module              | Key Rule (always applies)                                                    | Fetch for details                          |
+| ------------------- | ---------------------------------------------------------------------------- | ------------------------------------------ |
+| `secrets.md`        | Verify secret VALUES, not just key existence                                 | Infisical, vault, API keys, GitHub App     |
+| `content-policy.md` | Never auto-save to VCMS; agents ARE the voice                                | VCMS tags, storage rules, editorial, style |
+| `team-workflow.md`  | All changes through PRs; never push to main                                  | Full workflow, escalation triggers         |
+| `fleet-ops.md`      | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh | SSH, machines, Tailscale, macOS            |
 
 Fetch with: `crane_doc('global', '<module>')`
 


### PR DESCRIPTION
## Summary
Removes QA grading artifacts from tooling/config files as part of enterprise-wide cleanup.

## Changes
- `.claude/commands/sprint.md`: removed QA grade label extraction line (`qa-grade:*` / `qa:*`)
- `CLAUDE.md`: removed "QA grades" from the `team-workflow.md` module description

## Notes
- `.github/workflows/test-required.yml` left intact - that workflow tracks `test:required`/`test:exempt` labels, not QA grades
- All references in `src/content/articles/` and `src/content/pages/` left intact - those are published historical records

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>