### PR TITLE
content: honest Claude attribution pass across nav, articles, and logs

### DIFF
--- a/src/content/articles/agents-building-ui-never-seen.md
+++ b/src/content/articles/agents-building-ui-never-seen.md
@@ -7,7 +7,7 @@ tags: ['frontend', 'agent-workflow', 'product-development']
 draft: false
 ---
 
-Seventeen pull requests merged. Three AI Assist panels built with five states each. A full navigation redesign. Book Outline Mode. A shared component system. Design token migration. Forty-plus hours of agent development time.
+Seventeen pull requests merged. Three AI Assist panels built with five states each. A full navigation redesign. Book Outline Mode. A shared component system. Design token migration. Forty-plus hours of agent development time - Claude Code agents, working from design specs.
 
 The human directing all of it has never seen the app rendered in a browser.
 

--- a/src/content/articles/code-review-to-production-48-hours.md
+++ b/src/content/articles/code-review-to-production-48-hours.md
@@ -11,7 +11,7 @@ A code review graded a codebase at C. Forty-eight hours later, the same codebase
 
 The codebase was an iPad-first writing app for nonfiction authors. It had an existing foundation - authentication, basic editor, chapter structure - but the code review exposed real problems. A D in testing. Cs in security, architecture, and code quality. Drive query injection vectors in the Google Drive integration. A monolithic page component north of 1,200 lines. Near-zero test coverage on critical paths.
 
-What happened next was not a hackathon. It was a structured sprint where the code review findings became the work queue, ordered by severity, and AI agents worked through it systematically.
+What happened next was not a hackathon. It was a structured sprint where the code review findings became the work queue, ordered by severity, and Claude Code agents worked through it systematically.
 
 ---
 

--- a/src/content/articles/cross-venture-context-agent-awareness.md
+++ b/src/content/articles/cross-venture-context-agent-awareness.md
@@ -7,7 +7,7 @@ tags: ['agent-context', 'multi-tenant', 'agent-operations']
 draft: false
 ---
 
-We run multiple ventures across multiple repos on multiple machines. Each venture has its own repo, its own Infisical secrets path, its own design system, its own cadence, and its own content space. Agents work in one venture at a time - or they're supposed to.
+We run multiple ventures across multiple repos on multiple machines. Each venture has its own repo, its own Infisical secrets path, its own design system, its own cadence, and its own content space. Agents work in one venture at a time - or they're supposed to. Every agent session runs through Claude Code, which means the Start of Session briefing is the primary lever for establishing spatial context before any work begins.
 
 Agents don't have spatial awareness by default. They know what they're doing. They don't inherently know where they are, what that boundary means, or what lives outside it. When we started running multi-venture workloads, that gap produced a specific set of failures: wrong repos targeted, cadence items bleeding across ventures, secrets leaking through shared paths. Each was solvable in isolation. Together they pointed to an infrastructure gap we had to close.
 

--- a/src/content/articles/fleet-sprints-ai-agents.md
+++ b/src/content/articles/fleet-sprints-ai-agents.md
@@ -24,7 +24,7 @@ The sprint skill is a prompt-driven orchestrator. It does not manage long-runnin
 5. Spawn all agents in a single message for true parallelism
 6. Wait for completion, collect results, update labels
 
-Each agent receives a self-contained prompt: the issue body, the worktree path, the branch name, and the project's verification command. The agent implements, runs verification, commits, pushes, and opens a PR. If it fails verification three times, it stops and reports failure instead of shipping broken code.
+Each agent receives a self-contained prompt: the issue body, the worktree path, the branch name, and the project's verification command. Each one runs as a Claude Code session - the CLI harness handling tool orchestration, context, and the agent loop. The agent implements, runs verification, commits, pushes, and opens a PR. If it fails verification three times, it stops and reports failure instead of shipping broken code.
 
 The orchestrator only executes one wave per invocation. After Wave 1's PRs are reviewed and merged, you run the sprint skill again with the remaining issues. Wave 2 branches from the updated main. This eliminates inter-wave state management entirely - there is no state to manage.
 

--- a/src/content/articles/four-auth-vulnerabilities-one-code-review.md
+++ b/src/content/articles/four-auth-vulnerabilities-one-code-review.md
@@ -9,7 +9,7 @@ draft: false
 
 Four authentication vulnerabilities, all in production, all exploitable, all introduced during prototyping, all found in a single code review session. None of them were bugs in the traditional sense. The code worked. The tests passed. Every endpoint returned the right data for the right requests. The problem was that they also returned the right data for the wrong requests.
 
-The app is a family expense tracker for shared custody situations. It was built rapidly with AI agent assistance - functional prototype to working API in days, not weeks. That speed came with a cost we did not discover until we sat down to review the auth layer systematically.
+The app is a family expense tracker for shared custody situations. It was built rapidly with Claude Code agents - functional prototype to working API in days, not weeks. That speed came with a cost we did not discover until we sat down to review the auth layer systematically.
 
 The cost was not one vulnerability. It was a pattern.
 

--- a/src/content/articles/kill-discipline-ai-agents.md
+++ b/src/content/articles/kill-discipline-ai-agents.md
@@ -105,7 +105,7 @@ This seems bureaucratic until you have been burned by an issue that was closed a
 
 ## Kill Discipline as a Cultural Practice
 
-The most important thing about kill discipline is that it does not emerge naturally. You have to codify it explicitly and enforce it consistently. Without explicit rules in project instructions, every AI agent will default to optimistic persistence - trying one more thing, one more time, one more variation.
+The most important thing about kill discipline is that it does not emerge naturally. You have to codify it explicitly and enforce it consistently. Without explicit rules in project instructions, every AI agent will default to optimistic persistence - trying one more thing, one more time, one more variation. This applies directly to Claude Code sessions, where the rules are loaded fresh at session start and enforced throughout.
 
 Here is how we implement it in practice.
 

--- a/src/content/articles/lazy-loading-agent-context.md
+++ b/src/content/articles/lazy-loading-agent-context.md
@@ -7,7 +7,7 @@ tags: ['performance', 'mcp', 'agent-context']
 draft: false
 ---
 
-Our session startup routine was consuming 45,000 to 71,000 tokens before the agent did any useful work. On a ~200K context window, that is 22-35% of available capacity gone on initialization alone. We cut it to roughly 3,000 tokens - a 93-96% reduction - without changing the backend API.
+Our session startup routine was consuming 45,000 to 71,000 tokens before the agent did any useful work. On a ~200K context window, that is 22-35% of available capacity gone on initialization alone. We cut it to roughly 3,000 tokens - a 93-96% reduction - without changing the backend API. The agent in every session is Claude Code, so context window capacity is a direct cost: every token spent on unread documentation is a token unavailable for reasoning and code work.
 
 ## The Problem: Eager Loading
 

--- a/src/content/articles/secrets-injection-agent-launch.md
+++ b/src/content/articles/secrets-injection-agent-launch.md
@@ -18,7 +18,7 @@ The standard approach - `.env` files checked into repos or copied between machin
 - **Secrets in git history.** Accidentally commit a `.env` file. Remove it. It's still in the history. Now you're rotating keys and scrubbing refs.
 - **Agent exposure.** AI agents can accidentally include environment variable values in commit messages, PR descriptions, or tool call arguments. The blast radius of a secret in an agent's environment is larger than in a traditional dev setup.
 
-We built a CLI launcher that eliminates all of these failure modes. One command fetches the right secrets for the right project from Infisical (our centralized secrets manager), injects them into the agent process as environment variables, and spawns the session. No files on disk. No copy-paste. No guessing which `.env` is current.
+We built a CLI launcher that eliminates all of these failure modes. One command fetches the right secrets for the right project from Infisical (our centralized secrets manager), injects them into the agent process as environment variables, and spawns the session - typically a Claude Code session. No files on disk. No copy-paste. No guessing which `.env` is current.
 
 ---
 

--- a/src/content/articles/secrets-management-ai-agents.md
+++ b/src/content/articles/secrets-management-ai-agents.md
@@ -7,7 +7,7 @@ tags: ['secrets', 'infrastructure', 'agent-workflow', 'infisical']
 draft: false
 ---
 
-The threat model for AI agents is not the same as the threat model for human developers.
+The threat model for AI agents is not the same as the threat model for human developers. Our agent workforce runs on Claude Code - the CLI harness - which means every environment variable in scope at session launch is visible and referenceable by the agent for the duration of that session.
 
 A human developer might accidentally commit a `.env` file. That's bad. An AI agent might include an API key in a commit message, echo a secret into a tool call argument, or store a credential value in a knowledge system instead of a secrets manager - all while believing it completed the task correctly. Agents operate autonomously, often across multiple projects and machines, with every environment variable visible and referenceable. The blast radius of a secret in an agent's environment is wider than in a traditional development setup, and the failure modes are different.
 

--- a/src/content/articles/sessions-heartbeats-handoffs.md
+++ b/src/content/articles/sessions-heartbeats-handoffs.md
@@ -9,7 +9,7 @@ draft: false
 
 An AI coding agent is a process. It starts, does work, and eventually stops. Sometimes it stops gracefully. Sometimes it crashes. Sometimes the human closes the laptop and walks away. If you are running multiple agents across multiple machines, you need answers to the same questions you would ask about any distributed system process: Is it still alive? What was it working on? Did it finish? Can another process safely pick up where it left off?
 
-We built a session management system for AI agents that borrows directly from distributed systems infrastructure - liveness detection via heartbeats, crash recovery via idempotent handoffs, and coordination via session awareness. This article goes deep on the design of each layer.
+We built a session management system for AI agents that borrows directly from distributed systems infrastructure - liveness detection via heartbeats, crash recovery via idempotent handoffs, and coordination via session awareness. Every session in this system is a Claude Code session: the CLI harness that orchestrates tools, context, memory, and sub-agents across machines. This article goes deep on the design of each layer.
 
 ---
 

--- a/src/content/articles/staging-environments-ai-agents.md
+++ b/src/content/articles/staging-environments-ai-agents.md
@@ -7,7 +7,7 @@ tags: ['infrastructure', 'cloudflare-workers', 'ci-cd', 'staging']
 draft: false
 ---
 
-An AI agent running `npx wrangler deploy` during a development session just pushed to production. There was no staging environment. No gate. No confirmation prompt. The agent did exactly what it was told to do, and that was the problem.
+A Claude Code agent running `npx wrangler deploy` during a development session just pushed to production. There was no staging environment. No gate. No confirmation prompt. The agent did exactly what it was told to do, and that was the problem.
 
 When your deployment tooling has a single target and your "developers" are AI agents that execute commands literally, you get production deployments by default. A human developer might hesitate - "wait, is this production?" - and check the target before running the command. An agent runs the command. That is what agents do.
 

--- a/src/content/articles/when-the-agent-briefing-lies.md
+++ b/src/content/articles/when-the-agent-briefing-lies.md
@@ -33,7 +33,7 @@ The fourth was the verification layer. Endpoints that interrogate deployed state
 
 ## What directing agents through this actually looked like
 
-The tracks look clean in summary. They were not clean in execution. The work spanned two calendar days, $741 in model compute, and a pattern that surfaced early and repeated all the way through: agents declaring a track complete, the captain challenging the declaration, the agents finding a bug they had missed, the agents rewriting.
+The tracks look clean in summary. They were not clean in execution. The sessions ran on Claude Code - every track, every tool call, every rewrite. The work spanned two calendar days, $741 in model compute, and a pattern that surfaced early and repeated all the way through: agents declaring a track complete, the captain challenging the declaration, the agents finding a bug they had missed, the agents rewriting.
 
 The schema verification endpoint's first version baked the hash at CI time instead of reading the live database. It would have passed on any deployment where CI ran. It would not have caught a migration applied out of band or a schema that drifted between environments. The captain caught it. The secret-sync audit's first version compared the local config against itself. It would have reported "in sync" regardless of whether deployed workers matched. The captain caught that too.
 

--- a/src/content/articles/why-development-lab.md
+++ b/src/content/articles/why-development-lab.md
@@ -31,7 +31,7 @@ The result is that adding a new venture takes minutes, not days. The coordinatio
 
 ## The AI Agent Angle
 
-Shared infrastructure is not a new idea. Monorepos, platform teams, and internal developer platforms all address the same problem. What makes the development lab model different is that AI coding agents change the economics of how many codebases a small team can maintain.
+Shared infrastructure is not a new idea. Monorepos, platform teams, and internal developer platforms all address the same problem. What makes the development lab model different is that AI coding agents change the economics of how many codebases a small team can maintain. The agent workforce runs on Claude Code - Anthropic's CLI harness - as the primary interface for every development session across the portfolio.
 
 A solo founder without AI agents can realistically maintain one codebase at production quality. Maybe two if they're related. The bottleneck is human attention - context switching between unrelated codebases is expensive, and each one demands ongoing maintenance even when you're not actively building features.
 

--- a/src/content/articles/zero-to-landing-page-four-days.md
+++ b/src/content/articles/zero-to-landing-page-four-days.md
@@ -7,7 +7,7 @@ tags: ['venture-scaffolding', 'astro', 'agent-workflow']
 draft: false
 ---
 
-On 2026-03-24, we added a venture code to a registry file. On 2026-03-28, we wired a Calendly booking link into production CTA buttons on a live Astro site. Forty-six merged PRs and four days in between.
+On 2026-03-24, we added a venture code to a registry file. On 2026-03-28, we wired a Calendly booking link into production CTA buttons on a live Astro site. Forty-six merged PRs and four days in between. The agent sessions that produced this output ran through Claude Code - the CLI harness - with the venture registry and Infisical secrets injected at launch.
 
 The venture is an operations consulting firm serving small businesses in the Phoenix area. The target client is 5-50 employees, dealing with undocumented processes, leaky lead pipelines, and no financial visibility. Fixed-price engagements, clear deliverables, no open-ended retainers.
 

--- a/src/content/logs/2026-04-17-stitch-retirement.md
+++ b/src/content/logs/2026-04-17-stitch-retirement.md
@@ -1,0 +1,26 @@
+---
+title: 'Retiring Stitch from the design stack'
+date: 2026-04-17
+tags: ['design-tooling', 'process', 'cleanup']
+draft: false
+---
+
+On 2026-03-28 we published [a head-to-head evaluation of Figma MCP and Google Stitch](/articles/figma-vs-stitch-design-tool-evaluation/). Stitch won that bake-off. On 2026-04-17 we retired it. This entry closes the loop.
+
+## What changed
+
+In the weeks between the evaluation and the retirement, we built `/product-design` - an enterprise skill that runs inside Claude Code. The skill takes a nav-spec, a `DESIGN.md`, and a UX brief as inputs and produces Astro/React components directly in the venture's repo. It runs end-to-end in a single Claude Code session, no external API calls, no separate MCP server, no per-machine credential setup.
+
+We proved it on ss-console. One gate-zero run produced shippable components that matched the design spec. Stitch's core advantage - generating screens from prompts faster than Figma MCP - collapsed when the alternative stopped being "generate a screen" and became "produce the component you were going to build anyway."
+
+Figma MCP was already off the table. We removed it on the day of the bake-off (2026-03-28) on cost and API volume grounds - $700/year for a team plan plus a fragile WebSocket bridge that crashed twice in a single test session.
+
+## The mechanical mark
+
+Every venture that had a `.stitch/` directory got it renamed to `.design/`. Same contents - `NAVIGATION.md`, `DESIGN.md`, the venture's UX brief files - but a tool-agnostic name that no longer implies a specific external service. The rename happened in the retirement PR.
+
+Stitch project IDs that were registered in the venture registry are no longer referenced. The Stitch MCP package is no longer listed in any `.mcp.json`. The v0.5.0 pin note in the tooling docs is gone.
+
+## What this means going forward
+
+The design work did not stop. The evaluation article was accurate about the decision it described - Stitch was the right call on 2026-03-28. A better path opened three weeks later, and we took it. `/product-design` produces components where Stitch produced screens. The loop from design input to shippable output is shorter, and it runs entirely inside the agent surface we already use for everything else.

--- a/src/content/pages/about.md
+++ b/src/content/pages/about.md
@@ -29,7 +29,7 @@ Six named concepts make the system work.
 
 **Context.** Context is the information an agent needs to do useful work. It includes handoff state, the work queue, enterprise knowledge, and operational documentation. The system delivers context at session startup through an MCP server that lazy-loads only what's needed. See [Agent Context Management](/articles/agent-context-management-system/) and [96% Token Reduction](/articles/lazy-loading-agent-context/).
 
-**Tools.** Tools are the interfaces agents use to interact with external systems - GitHub issues, CI pipelines, documentation stores, deployment targets. Tools are typed, validated, and delivered through MCP. See [Building an MCP Server](/articles/building-mcp-server/).
+**Tools.** Tools are the interfaces agents use to interact with external systems - GitHub issues, CI pipelines, documentation stores, deployment targets. Tools are typed, validated, and delivered through MCP. The agent workforce runs on Claude Code - Anthropic's CLI harness - with Claude as the foundation model. See [Building an MCP Server](/articles/building-mcp-server/).
 
 **Environments.** Every agent runs on a physical machine in a managed fleet. Environments are bootstrapped identically: same CLI tools, same SSH mesh, same secrets injection. Adding a machine takes minutes. See [Fleet Management for One Person](/articles/fleet-management-solo/).
 
@@ -55,7 +55,7 @@ Every agent session follows the same structure, whether it's a thirty-minute bug
 
 If you only read three articles, read these.
 
-<!-- Curated list — review when new methodology articles publish -->
+<!-- Curated list - review when new methodology articles publish -->
 
 - [Kill Discipline for AI Agent Teams](/articles/kill-discipline-ai-agents/) - Five mandatory stop rules that force agents to escalate instead of spiral. The most important operational pattern we've found.
 - [Multi-Agent Team Protocols Without Chaos](/articles/multi-agent-team-protocols/) - How agents and humans coordinate without stepping on each other.

--- a/src/content/pages/guide.md
+++ b/src/content/pages/guide.md
@@ -3,7 +3,7 @@ title: 'Start Here'
 updatedDate: 2026-02-16
 ---
 
-Curated reading paths through everything we've published. Each article is a field note from running AI agent teams in production - real costs, real failures, real infrastructure decisions.
+Curated reading paths through everything we've published. Each article is a field note from running AI agent teams in production - real costs, real failures, real infrastructure decisions. Primary agent: Claude Code via Anthropic Max.
 
 ## Where should I start?
 

--- a/src/content/pages/open-problems.md
+++ b/src/content/pages/open-problems.md
@@ -3,7 +3,7 @@ title: 'Open Problems'
 updatedDate: 2026-02-16
 ---
 
-AI-native development is a young discipline. We've solved some problems well enough to write about them. These are the ones we haven't. We publish them because hard problems get solved faster when more people are looking at them.
+AI-native development is a young discipline. We've solved some problems well enough to write about them. These are the ones we haven't - challenges we encounter daily running Claude Code sessions. We publish them because hard problems get solved faster when more people are looking at them.
 
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,9 @@ const remainingArticles = articles.slice(1, 5)
     </h1>
     <p class="mt-2 text-vc-text-muted">
       One studio, AI agent teams, real costs, honest failures. Most AI development content is vendor
-      marketing or tutorials. This is what it actually looks like to ship products with agents.
+      marketing or tutorials. This is what it actually looks like to ship products with agents. The
+      agent workforce runs on Claude Code - Anthropic's CLI harness - with Claude as the foundation
+      model.
     </p>
     <p class="mt-3 text-sm text-vc-text-muted">
       New here?


### PR DESCRIPTION
## Summary

Phase 2 of the venturecrane.com positioning update for the Claude Partner Network pursuit. Surgical, honest Claude and Claude Code attribution added to nav pages, articles, and one new ship-log entry. Every sentence uses canonical framings from the pattern doc; no restructuring, no retrofitting, no overclaim.

Companion PR on the crane-console side (Phase 1 audit + positioning pattern doc + engagement inventory): https://github.com/venturecrane/crane-console/pull/646

## What changed

**Nav and methodology pages (4):**

- `src/pages/index.astro` | homepage: Claude Code named in the intro sentence
- `src/content/pages/about.md` | The System: Claude Code named in the Tools primitive
- `src/content/pages/guide.md` | Start Here: primary-agent line added to intro
- `src/content/pages/open-problems.md` | CC CLI sessions grounded in the problem context

**High-priority articles (5):**

- `why-development-lab.md`
- `when-the-agent-briefing-lies.md`
- `agents-building-ui-never-seen.md`
- `kill-discipline-ai-agents.md`
- `fleet-sprints-ai-agents.md`

**Medium-priority articles (9 edited, 3 skipped):**

- Edited: cross-venture-context-agent-awareness, zero-to-landing-page-four-days, code-review-to-production-48-hours, secrets-management-ai-agents, secrets-injection-agent-launch, lazy-loading-agent-context, sessions-heartbeats-handoffs, four-auth-vulnerabilities-one-code-review, staging-environments-ai-agents
- Skipped (already-good on re-read): forty-hours-one-auth-bug, tool-registration-not-integration, fleet-management-solo

**New ship-log entry (1):**

- `src/content/logs/2026-04-17-stitch-retirement.md` | closes the historical inaccuracy on the Stitch evaluation article. Names `/product-design` as the replacement running inside Claude Code. References the `.stitch/` to `.design/` rename. Honest note on Figma MCP rejection earlier (2026-03-28).

## Voice compliance

- Zero em dashes across all 19 touched files (programmatically verified)
- No overclaim of partnership or certification status
- Tool attribution per the positioning-pattern lexicon: Claude Code = CLI harness, Claude = model family, Anthropic = platform, Claude API = HTTP inference. No conflation.
- All added sentences adapted from Section 3 canonical framings in `venturecrane-site-positioning-pattern.md`

## Out of scope

Intentionally NOT edited (per the audit):

- 9 already-good articles that accurately attribute Claude or Claude Code already
- `local-llms-offline-field-development` (retrofit-risk; original framing is correct)
- `figma-vs-stitch-design-tool-evaluation` (historically accurate for its time; new ship-log entry covers the current state)

Pre-existing unstaged changes in `.claude/settings.json` and `src/VC Web Content/` were deliberately NOT swept into this commit.

## Test plan

- [ ] Review a sample of edits for tone and placement (homepage + `why-development-lab` recommended)
- [ ] Review the new `2026-04-17-stitch-retirement.md` ship-log entry for voice match with existing logs
- [ ] Check `cloudflare pages` preview deploy for visual regressions
- [ ] Confirm no partnership-overclaim language before flip to ready-for-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>