### PR TITLE
content(terminology): add Claude Attribution section + test fixture

### DIFF
--- a/docs/content/terminology.md
+++ b/docs/content/terminology.md
@@ -17,6 +17,77 @@ Read this before drafting any content for venturecrane.com. These are the canoni
 | Infisical        | "secrets manager" alone                             | Name the tool. "Infisical" on first reference, "secrets manager" acceptable in subsequent references within the same article. |
 | GitHub App       | "the bot", "the integration"                        | The venturecrane-github app (App ID 2619905).                                                                                 |
 
+## Claude Attribution
+
+Editorial checks for content that describes VC's Claude / Anthropic relationship and tooling. The `/edit-article` and `/edit-log` skills enforce these before publish.
+
+### 1. Partnership Relationship - Canonical Form
+
+The only approved characterizations of the VC-Anthropic partnership relationship are:
+
+- "in the Claude Partner Network" (adjective / prepositional use)
+- "pursuing Partner Network status" (verb form)
+- "applied to the Claude Partner Network" (past-action verb form)
+
+Any other characterization of the relationship is BLOCKING. Examples of forms that must be flagged and rewritten:
+
+- "Claude Certified Partner" | misstates certification (we are not certified)
+- "Anthropic Certified" | misstates certification
+- "Claude Partner Network Member" | implies full membership (we are in pipeline)
+- "Official Claude Partner" | implies finalized status
+- "Claude Partner" standalone | ambiguous, reads as claim
+
+Editor-agent rule: check each sentence that characterizes the Anthropic relationship. If the characterization matches a canonical form verbatim, pass. Otherwise, flag BLOCKING and propose a rewrite toward the closest canonical form. Do NOT auto-fix; rewrites are human-review only because surrounding context shapes which canonical form fits.
+
+### 2. Tool Attribution Lexicon
+
+| Term                      | What it means                                                                        | When to use                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| Claude Code (also CC CLI) | The command-line agent harness (interactive sessions, CLAUDE.md, skills, MCP client) | Content describing agent sessions, CLI workflow, interactive work |
+| Claude API                | Direct HTTP inference via `https://api.anthropic.com/v1/messages`                    | Content describing production workers, batch jobs, cron pipelines |
+| MCP                       | Model Context Protocol (wire-level tool / resource exposure). Not itself an agent.   | Content describing tool integration, resource surfaces            |
+| Agent SDK                 | The framework for building custom agent harnesses. Distinct from Claude Code.        | Content describing custom harness development                     |
+| Claude Managed Agents     | Anthropic's managed agent infrastructure (launched 2026-04-08)                       | Content describing managed autonomous deployment                  |
+| claude.ai                 | Anthropic's web chat interface                                                       | Content describing web-based Claude use                           |
+| Anthropic Academy         | The training curriculum (courses)                                                    | Content describing Partner Network training path                  |
+| Claude alone              | The model family (`claude-sonnet-4-6`, Haiku, etc.)                                  | When the specific integration point does not matter               |
+
+### 3. Venture-to-Integration Mapping
+
+Editor agents use this mapping to distinguish correct tool attribution from conflation:
+
+| Venture / component                                     | Current shipping integration              | Development layer |
+| ------------------------------------------------------- | ----------------------------------------- | ----------------- |
+| SS pipelines (review-mining, job-monitor, new-business) | Claude API (direct HTTP)                  | Claude Code       |
+| DFG analyst worker                                      | Claude API (direct HTTP)                  | Claude Code       |
+| crane-mcp, crane-mcp-remote                             | MCP infrastructure (protocol, not agent)  | Claude Code       |
+| DC, KE, SC product code                                 | None at product layer (Claude in backlog) | Claude Code       |
+| All ventures                                            | N/A                                       | Claude Code       |
+
+Conflation rules (all BLOCKING):
+
+- "Claude" used when the sentence describes a specific SS or DFG pipeline call -> fix to "the Claude API"
+- "Claude Code" used when the sentence describes a direct HTTP API call -> fix to "the Claude API"
+- "MCP" used as if it were the agent itself -> fix to "Claude Code" or "the agent"
+- "Claude Code" used when describing development-layer work on any venture -> passes (always accurate)
+
+Auto-fix rule: apply fix only when the venture-to-integration mapping yields an unambiguous target. If a sentence is ambiguous (mentions both layers, or references "our AI" without grounding), flag for human review.
+
+### 4. Generic AI-Agent Language Advisory + Retrofit Heuristic
+
+Content that describes concrete Claude Code work (CLAUDE.md references, session management, CC CLI commands, MCP tools, fleet dispatch, agent-session orchestration) should name Claude Code rather than using "AI agent" / "AI coding CLI" generically.
+
+**Retrofit-risk exception via mechanical two-question heuristic:**
+
+1. Does the article's title or H1 describe a Claude Code capability, workflow, or session? If YES, the retrofit exception does NOT apply (flag as advisory).
+2. Does the content already name Claude Code at least once? If YES, the retrofit exception does NOT apply (additional specific attribution is consistent with original scope; flag as advisory).
+
+Only if both answers are NO does the retrofit exception apply (suppress the finding entirely). This makes the exception a checklist step, not a judgment call.
+
+Advisory only. Not auto-fixed.
+
+See `~/dev/crane-console/docs/anthropic-partnership/briefs/venturecrane-site-positioning-pattern.md` for canonical framings and page-type playbook used by Phase 2 editors of the April 2026 site pivot. The pattern doc is a snapshot; this terminology.md section is the living registry.
+
 ## Self-Reference Style
 
 - **Articles**: Third-person ("Venture Crane uses...") or first-person plural ("We built..."). Never "I" in articles.

--- a/docs/test-fixtures/edit-skill-claude-attribution-fixture.md
+++ b/docs/test-fixtures/edit-skill-claude-attribution-fixture.md
@@ -1,0 +1,37 @@
+---
+title: '[FIXTURE] Claude Attribution Edit-Skill Test Fixture'
+description: Deliberate violations for smoke-testing /edit-article and /edit-log Claude attribution checks. Not for publication.
+pubDate: 2026-04-22
+draft: true
+testFixture: true
+excludeFromBuild: true
+tags: ['test-fixture']
+---
+
+# [FIXTURE] Claude Attribution Edit-Skill Test Fixture
+
+This file is a deterministic test fixture. It contains exactly three violations of the Claude Attribution rules in `docs/content/terminology.md`. Running `/edit-article` or `/edit-log` on this file should produce exactly three findings: two BLOCKING and one ADVISORY. Do not edit the violations below without updating the smoke-test expectations in the skill plan doc.
+
+## Violation 1 - Partnership overclaim (BLOCKING)
+
+As a Claude Certified Partner, we deliver operational consulting to Phoenix small businesses with Claude-powered lead qualification and delivery tooling.
+
+Expected finding: BLOCKING. "Claude Certified Partner" misstates certification. Canonical form per terminology.md Section 1 is "in the Claude Partner Network" or "pursuing Partner Network status." Auto-fix: not applied (rewrite is human-review only).
+
+## Violation 2 - Tool attribution conflation (BLOCKING)
+
+We used Claude Code to score leads in the review-mining pipeline, tuning the sonnet-class model over a weekly cadence.
+
+Expected finding: BLOCKING. Per the venture-to-integration mapping in terminology.md Section 3, SS review-mining uses the Claude API (direct HTTP), not Claude Code (the CLI harness). The sentence describes a production cron worker call, which is Claude API by definition. Auto-fix: "Claude Code" -> "the Claude API."
+
+## Violation 3 - Generic AI-agent language in clear CC CLI context (ADVISORY)
+
+Before any agent session begins, the AI coding CLI loads the CLAUDE.md file at the repo root and every `.claude/rules/` match for the files the session will touch. The agent then reads the venture registry and joins the fleet via crane-mcp.
+
+Expected finding: ADVISORY. The paragraph describes concrete Claude Code work (CLAUDE.md, `.claude/rules/`, crane-mcp integration). The retrofit heuristic in terminology.md Section 4 does not apply: this fixture's title contains "Claude Attribution" so heuristic question 1 answers YES (a Claude-specific framing). Suggestion: "the AI coding CLI" -> "Claude Code." Not auto-fixed.
+
+## Control passage (no findings expected)
+
+Our development layer runs on Claude Code across every venture. The pattern is consistent: a Claude Code session reads CLAUDE.md, loads path-scoped rules, and dispatches to fleet machines via crane-mcp. When we need production-scale inference outside the development layer, we call the Claude API directly from Cloudflare Workers cron jobs.
+
+Expected: no findings. Accurate attribution throughout; canonical tool terms for each layer.


### PR DESCRIPTION
## Summary

Extends `docs/content/terminology.md` with a new `## Claude Attribution` section that `/edit-article` and `/edit-log` read as source of truth for three new editorial checks. Also adds a deterministic test fixture at `docs/test-fixtures/edit-skill-claude-attribution-fixture.md` so the smoke-test step for the companion crane-console PR is not theoretical.

## What's in Claude Attribution

Four subsections:

1. **Partnership-relationship canonical form.** Positive whitelist: "in the Claude Partner Network," "pursuing Partner Network status," "applied to the Claude Partner Network." Any other characterization of the Anthropic relationship is BLOCKING with rewrite proposed; no auto-fix.
2. **Tool attribution lexicon.** 8-row table: Claude Code (CC CLI), Claude API, MCP, Agent SDK, Claude Managed Agents, claude.ai, Anthropic Academy, Claude alone (the model family).
3. **Venture-to-integration mapping.** Tells editor agents which layer each VC component operates at so they can classify conflation: SS / DFG pipelines = Claude API, crane-mcp = MCP, DC/KE/SC product = backlog, development layer = Claude Code across all ventures.
4. **Generic AI-agent advisory rule + two-question retrofit heuristic.** Replaces an open-ended judgment call with a mechanical checklist: if title describes Claude Code work OR content already names Claude Code, the retrofit exception does NOT apply.

## What's in the fixture

`docs/test-fixtures/edit-skill-claude-attribution-fixture.md`. Contains exactly three deliberate violations plus a clean control passage:

- 1 BLOCKING overclaim: "As a Claude Certified Partner, we ..."
- 1 BLOCKING conflation: "Claude Code" in a review-mining pipeline context (should be Claude API per the mapping)
- 1 ADVISORY generic-AI-agent: "the AI coding CLI" in a paragraph that describes CLAUDE.md, `.claude/rules/`, and crane-mcp (retrofit exception does NOT apply)

Frontmatter: `draft: true`, `testFixture: true`, `excludeFromBuild: true`. File path outside `src/content/` keeps it out of Astro's published collections.

## Companion PR

crane-console side (both `.agents/skills/edit-article/SKILL.md` and `.agents/skills/edit-log/SKILL.md`) lands the three checks that reference this terminology section. The two PRs can merge in either order; the skills gracefully degrade if terminology.md has not been updated yet (they just do not catch the new issues).

## Test plan

After the crane-console companion PR merges:

- [ ] Run `/edit-article ~/dev/vc-web/docs/test-fixtures/edit-skill-claude-attribution-fixture.md` and confirm exactly 3 findings (2 BLOCKING, 1 ADVISORY)
- [ ] Run `/edit-article` on `src/content/articles/where-we-stand-agent-operations-2026.md` (audit-marked already-good) and confirm zero new-check findings
- [ ] Run `/edit-log` on `src/content/logs/2026-04-17-stitch-retirement.md` (authored in today's Phase 2 pass) and confirm zero new-check findings

## Voice compliance

- Zero em dashes in both modified files
- No overclaim language in the terminology doc itself (all partnership references use canonical forms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>