### PR TITLE
fix(fixture): remove genericization + overgeneralization noise

### DIFF
--- a/docs/test-fixtures/edit-skill-claude-attribution-fixture.md
+++ b/docs/test-fixtures/edit-skill-claude-attribution-fixture.md
@@ -26,12 +26,12 @@ Expected finding: BLOCKING. Per the venture-to-integration mapping in terminolog
 
 ## Violation 3 - Generic AI-agent language in clear CC CLI context (ADVISORY)
 
-Before any agent session begins, the AI coding CLI loads the CLAUDE.md file at the repo root and every `.claude/rules/` match for the files the session will touch. The agent then reads the venture registry and joins the fleet via crane-mcp.
+Before any agent session begins, the AI coding CLI loads the CLAUDE.md file at the repo root and every `.claude/rules/` match for the files the session will touch. The agent then reads the venture registry and joins the fleet via the MCP server.
 
-Expected finding: ADVISORY. The paragraph describes concrete Claude Code work (CLAUDE.md, `.claude/rules/`, crane-mcp integration). The retrofit heuristic in terminology.md Section 4 does not apply: this fixture's title contains "Claude Attribution" so heuristic question 1 answers YES (a Claude-specific framing). Suggestion: "the AI coding CLI" -> "Claude Code." Not auto-fixed.
+Expected finding: ADVISORY. The paragraph describes concrete Claude Code work (CLAUDE.md, `.claude/rules/`, MCP integration). The retrofit heuristic in terminology.md Section 4 does not apply: this fixture's title contains "Claude Attribution" so heuristic question 1 answers YES (a Claude-specific framing). Suggestion: "the AI coding CLI" -> "Claude Code." Not auto-fixed.
 
 ## Control passage (no findings expected)
 
-Our development layer runs on Claude Code across every venture. The pattern is consistent: a Claude Code session reads CLAUDE.md, loads path-scoped rules, and dispatches to fleet machines via crane-mcp. When we need production-scale inference outside the development layer, we call the Claude API directly from Cloudflare Workers cron jobs.
+Our development layer runs on Claude Code across every venture. The pattern is consistent: a Claude Code session reads CLAUDE.md, loads path-scoped rules, and dispatches to fleet machines via the MCP server. When we need production-scale inference outside the development layer, we call the Claude API directly from Cloudflare Workers.
 
 Expected: no findings. Accurate attribution throughout; canonical tool terms for each layer.


### PR DESCRIPTION
## Summary

Cleanup pass on the Claude-attribution test fixture after smoke-testing on main. The fixture was correctly triggering two sets of **unintended** findings from existing checks (genericization `crane-mcp` blocks, Fact-Checker cron-worker overgeneralization). These had nothing to do with the three new checks the fixture exists to exercise, but they made the expected-findings count non-deterministic.

Four surgical changes:

- Line 29 prose: "joins the fleet via crane-mcp" -> "via the MCP server"
- Line 31 explanatory text: "crane-mcp integration" -> "MCP integration"
- Line 35 prose: "dispatches to fleet machines via crane-mcp" -> "via the MCP server"
- Line 35 prose: "Cloudflare Workers cron jobs" -> "Cloudflare Workers"

## Result

Running `/edit-article` on the cleaned fixture now produces exactly the 3 findings documented in the plan:

- 1 BLOCKING: partnership overclaim ("Claude Certified Partner")
- 1 BLOCKING: tool attribution conflation ("Claude Code" in SS review-mining context)
- 1 ADVISORY: generic AI-agent ("the AI coding CLI" in CC CLI context; retrofit exception does not apply)

Control passage is clean; no findings expected or produced.

## Voice

Zero em dashes in the fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>