### PR TITLE
content(article): pursuing Partner Network status as solo operator with AI agent team

### DIFF
--- a/src/content/articles/partner-network-solo-with-ai-agents.md
+++ b/src/content/articles/partner-network-solo-with-ai-agents.md
@@ -1,0 +1,72 @@
+---
+title: 'Pursuing Partner Network Status as a Solo Operator with an AI Agent Team'
+date: 2026-04-23
+description: 'What it looks like when a non-traditional operation applies to a program built for traditional services firms - and why transparent framing is the strategy, not a liability.'
+author: 'Venture Crane'
+tags: ['anthropic', 'claude-code', 'partnership', 'strategy']
+draft: false
+---
+
+The Claude Partner Network is designed for consulting firms and technology companies with engineering teams, client rosters, and sales pipelines. Venture Crane is one operator and a fleet of AI agents. We applied anyway - and we decided that the unusual shape of the operation is the argument for acceptance, not the obstacle to it.
+
+This article covers what pursuing Partner Network status actually looks like for a non-traditional operation: the three tracks, the form-gate that complicates one of them, the 30-day Foundations exam push, and the strategic logic behind leading with transparent framing instead of manufacturing the appearance of a conventional firm.
+
+## The shape of the application
+
+The Claude Partner Network offers several entry points. We are pursuing three simultaneously.
+
+The first runs through the consulting line. A services operation offering AI strategy and implementation to external clients maps to the Solution Partner track. The complication here is real: one track requires 10 individuals at the company-domain email to complete four Anthropic Academy courses before the application clears a form gate. With one operator, that path requires a response from Anthropic partner support before we know whether to pursue it or route around it. That question is drafted and waiting to send.
+
+The second runs through the venture portfolio. Multiple active products use the Claude API at the application layer - pipelines for review mining, market monitoring, and content analysis, plus the MCP server that powers every Claude Code agent session. The Technology Partner track maps to this footprint. This is the strongest lane technically.
+
+The third is individual: the founder as a Claude Certified Architect candidate. The certification path requires passing the Foundations exam, a credentialing step that covers agentic loop mechanics, tool use patterns, prompt engineering, and production deployment. We are running a 30-day study and preparation arc, with the exam sit window in late May.
+
+Three applications, three different vehicles. The form-gate finding on the Solution Partner path is the most concrete uncertainty we are carrying. The rest is execution.
+
+## Why transparent framing is the strategy
+
+The instinct when applying to a program built for firms with engineering benches is to paper over the difference. Emphasize the client work, downplay the headcount, present the operation as close to the template as possible.
+
+We went the other direction.
+
+Every document we filed with Anthropic describes the operation plainly: one operator directing AI agents, no manufactured staff, no fabricated bench. The consulting site delivers work produced by Claude Code agents operating in a structured session-and-handoff environment. The venture portfolio is built by agents. The codebase itself was written in Claude Code sessions. The content you are reading now was drafted by an agent.
+
+This is not an embarrassing edge case to minimize. It is the entire argument for partnership. Dario Amodei, speaking at Code with Claude in May 2025, put a 70-80% probability on the first one-person billion-dollar company emerging by 2026. Venture Crane is attempting to be existence proof - not a prediction but an actual operating demonstration of what one operator can build and sustain with an organized agent workforce.
+
+The partner program is interested in practitioners who build serious things with Claude and can speak credibly about it. We can speak credibly about it because we are not using Claude as a productivity supplement. Claude Code is the operational backbone. The work would not exist without it.
+
+Presenting that as a liability would be dishonest. It would also be strategically backward. The interesting thing we have to offer is the demonstration.
+
+## What the operation actually looks like
+
+Every session in the development environment runs through Claude Code. CLAUDE.md files carry standing orders, style rules, domain conventions, and escalation triggers into each agent session. A handoff system moves state between sessions - what was accomplished, what is in flight, what the next agent needs to pick up without ambiguity. The fleet spans multiple machines with shared context.
+
+The session structure is what makes a single operator workable at this scale. Without it, each agent session would start cold. With it, the agents inherit context accumulated across weeks of work. The captain's role is direction, verification, and editorial judgment. The agents handle implementation.
+
+The Claude API runs the production workers: review-mining pipelines, market monitoring, content analysis. These are not proof-of-concept prototypes. They are in production, running on schedules, producing output that feeds real work. Claude Code is the harness for everything in development - every venture, every infrastructure change, every article in this publication.
+
+The distinction matters for the partner application. Technology Partner status is grounded in what runs in production. The answer there is concrete. Individual Architect certification is grounded in technical depth with Claude. That depth is real and daily, not theoretical.
+
+## The Foundations exam and what it covers
+
+The certification path to Individual Claude Certified Architect status requires passing a Foundations exam. The exam covers agentic loop mechanics (stop reason handling, tool use versus end turn, anti-patterns), multi-agent orchestration, prompt engineering, safety and responsible use, and production deployment patterns.
+
+We have a 30-day curriculum running daily study sessions through the exam window. The gap ledger tracks specific weak areas. Agentic loop mechanics is first because it is where edge-case production behavior lives - the difference between an agent that handles tool errors gracefully and one that loops or halts incorrectly is in the stop_reason handling, and that is the kind of thing the exam specifically probes.
+
+The curriculum is structured as: study, self-test, gap record, next session. The cadence events are on the calendar. The exam is not a formality.
+
+## What we do not know yet
+
+The partner-support email, once sent, asks how Anthropic accommodates an operation that does not have 10 individuals for the form gate. The answer shapes the Solution Partner path. If the program cannot accommodate a one-operator firm on that track, we will route to the other two. If it can, the consulting line becomes a stronger part of the application.
+
+The Technology Partner track has no published gate that creates a structural problem. The venture portfolio footprint meets the technical bar.
+
+The Individual Architect path is purely execution-dependent. The exam sits in May.
+
+## The point
+
+The interesting story is not "solo operator gets lucky and squeezes through a partnership program." The interesting story is what happens when the program encounters an application that does not fit the expected shape but does fit the underlying intent - deep, active, production Claude usage - and has to decide what that means.
+
+We applied in the Claude Partner Network with a transparent description of what we are. We are pursuing Partner Network status because the work qualifies, not because we can make the operation look like something it is not. The Foundations exam is part of demonstrating depth, not just checking a box.
+
+The transparent framing is not a concession. It is the entire argument.

--- a/src/content/articles/partner-network-solo-with-ai-agents.md
+++ b/src/content/articles/partner-network-solo-with-ai-agents.md
@@ -1,7 +1,7 @@
 ---
 title: 'Pursuing Partner Network Status as a Solo Operator with an AI Agent Team'
 date: 2026-04-23
-description: 'What it looks like when a non-traditional operation applies to a program built for traditional services firms - and why transparent framing is the strategy, not a liability.'
+description: 'A solo operator with an AI agent team applies to a partner program built for services firms. Transparent framing is the strategy, not the liability.'
 author: 'Venture Crane'
 tags: ['anthropic', 'claude-code', 'partnership', 'strategy']
 draft: false


### PR DESCRIPTION
## Summary

- New article: `src/content/articles/partner-network-solo-with-ai-agents.md`
- Covers the three-track CPN application, the form-gate complication on the Solution Partner path, and the strategic logic of transparent solo + AI framing
- 800-1200 word target; delivered at ~950 words
- Date: 2026-04-23, author: Venture Crane, tags: anthropic, claude-code, partnership, strategy

## Editorial review (/edit-article)

**Blocking checks - all CLEAN:**
- Partnership canonical forms: "pursuing Partner Network status" and "applied in the Claude Partner Network" used throughout; no "Claude Partner", "Claude Partner Network Member", "Official Claude Partner", or "Anthropic Certified" anywhere
- Tool attribution: "Claude API" for production workers, "Claude Code" for development harness - correctly attributed per terminology.md Section 2-3
- No crane-* infrastructure names in prose
- No venture codes (vc, ke, sc, dfg, dc) in prose
- No specific venture counts
- No stealth venture names
- No "venturecrane" in prose
- No em dashes; no "I" in prose

**Advisory (not blocking, flagged for Captain review):**
- Line 34: "speaking at Code with Claude in May 2025" - event name sourced from handoff material; cannot verify official event name from available sources. Captain should confirm the exact event name before publish.

## SENSITIVE CONTENT - Captain review requested

This article touches the CPN application framing directly. Per the task brief, Captain should personally review:
1. All canonical-form usage for the partnership relationship
2. The Dario Amodei quote framing (line 34) and event name
3. The description of the three partner tracks and their status

## Test plan

- [ ] Captain reads for canonical-form compliance (partnership characterizations)
- [ ] Captain confirms "Code with Claude in May 2025" event name is accurate
- [ ] Captain confirms three-track description matches current application state
- [ ] Verify no draft flag needed (article is ready per editorial review)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>