### PR TITLE
fix(articles): correct publish dates from 2026-04-23 to 2026-04-22

### DIFF
--- a/src/content/articles/claude-code-plugins-fleet-rollout.md
+++ b/src/content/articles/claude-code-plugins-fleet-rollout.md
@@ -1,6 +1,6 @@
 ---
 title: 'Rolling Out Six Claude Code Plugins Across a Fleet'
-date: 2026-04-23
+date: 2026-04-22
 description: 'Anthropic shipped a Claude Code plugin marketplace. We picked six, set precise triggers for each, and pushed them across the fleet in one session.'
 author: 'Venture Crane'
 tags: ['claude-code', 'plugins', 'agent-tooling', 'fleet-management']

--- a/src/content/articles/github-packages-migration.md
+++ b/src/content/articles/github-packages-migration.md
@@ -1,6 +1,6 @@
 ---
 title: 'Migrating an Agent Fleet from Tarball Installs to a Private npm Registry'
-date: 2026-04-23
+date: 2026-04-22
 description: '12 critical Dependabot alerts, one incomplete migration, and four PRs to finish the job. What the move from tarball URLs to GitHub Packages actually looks like.'
 author: 'Venture Crane'
 tags: ['infrastructure', 'ci-cd', 'github-packages', 'monorepo']

--- a/src/content/articles/killing-skills-on-purpose.md
+++ b/src/content/articles/killing-skills-on-purpose.md
@@ -1,6 +1,6 @@
 ---
 title: 'Killing Skills on Purpose: A 32-to-24 Retirement Cascade'
-date: 2026-04-23
+date: 2026-04-22
 description: 'How a full-day audit cut a 32-skill catalog to 24 - and the operational tests that determined what earned retirement vs. what earned a stay.'
 author: 'Venture Crane'
 tags: ['agent-tooling', 'process', 'agent-operations']

--- a/src/content/articles/operating-ethos-agent-infrastructure.md
+++ b/src/content/articles/operating-ethos-agent-infrastructure.md
@@ -1,6 +1,6 @@
 ---
 title: 'Shipping a Cultural Directive Your Agents Read at Session Start'
-date: 2026-04-23
+date: 2026-04-22
 description: "Captain's standing order kept getting forgotten. The fix: commit it to a file agents read at session start - and learn what text belongs there."
 author: 'Venture Crane'
 tags: ['agent-context', 'agent-operations', 'process']

--- a/src/content/articles/own-it-behavioral-skill.md
+++ b/src/content/articles/own-it-behavioral-skill.md
@@ -1,6 +1,6 @@
 ---
 title: 'When a Behavioral Reflex Becomes a Slash Command'
-date: 2026-04-23
+date: 2026-04-22
 description: 'A directive repeated enough times got shipped as a skill. When that is the right call, and when memory or CLAUDE.md would have been the wrong tool.'
 author: 'Venture Crane'
 tags: ['agent-workflow', 'skills', 'process']

--- a/src/content/articles/partner-network-solo-with-ai-agents.md
+++ b/src/content/articles/partner-network-solo-with-ai-agents.md
@@ -1,6 +1,6 @@
 ---
 title: 'Pursuing Partner Network Status as a Solo Operator with an AI Agent Team'
-date: 2026-04-23
+date: 2026-04-22
 description: 'A solo operator with an AI agent team applies to a partner program built for services firms. Transparent framing is the strategy, not the liability.'
 author: 'Venture Crane'
 tags: ['anthropic', 'claude-code', 'partnership', 'strategy']


### PR DESCRIPTION
## Summary

Six articles from last session's content sprint were stamped with tomorrow's date (2026-04-23) even though they shipped to the site yesterday (2026-04-22). Commits landed at 20:13 Pacific / 03:13 UTC, so the drafting agent likely used UTC when setting the `date` frontmatter field.

The site doesn't gate publishing on `date` — it just sorts — so these articles have been live all day but displaying "Apr 23" on the cards and feed, reading as future/scheduled to anyone viewing the site.

Each file is a single one-line frontmatter change: `date: 2026-04-23` → `date: 2026-04-22`. No content changes.

## Affected articles

- `claude-code-plugins-fleet-rollout.md`
- `github-packages-migration.md`
- `killing-skills-on-purpose.md`
- `operating-ethos-agent-infrastructure.md`
- `own-it-behavioral-skill.md`
- `partner-network-solo-with-ai-agents.md`

## Follow-up

The `/build-article` skill (or whatever drafted these) should use local time, not UTC, when writing the `date` field. Not in scope for this PR, but worth a fix in the pipeline.

## Test plan

- [ ] CI green
- [ ] Preview deploy shows all six articles with date "Apr 22, 2026"
- [ ] RSS feed orders them before 2026-04-23 content (none exists yet, so any older article)

🤖 Generated with [Claude Code](https://claude.com/claude-code)