### PR TITLE
ci(content): harden test-required workflow and reject future-dated content

### DIFF
--- a/.github/workflows/test-required.yml
+++ b/.github/workflows/test-required.yml
@@ -21,7 +21,7 @@ jobs:
             const prBody = context.payload.pull_request.body || '';
             const branchName = context.payload.pull_request.head.ref || '';
             const bodyMatch = prBody.match(/(?:fixes|closes|resolves|ref|references?)?\s*#(\d+)/i);
-            const branchMatch = branchName.match(/(\d+)/);
+            const branchMatch = branchName.match(/#(\d+)/);
             let issueNumber = null;
             if (bodyMatch) {
               issueNumber = parseInt(bodyMatch[1]);
@@ -44,17 +44,27 @@ jobs:
         with:
           script: |
             const issueNumber = ${{ steps.get-issue.outputs.issue_number }};
-            const { data: issue } = await github.rest.issues.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-            });
-            const labels = issue.labels.map(l => l.name);
-            console.log(`Issue #${issueNumber} labels: ${labels.join(', ')}`);
-            const hasTestRequired = labels.includes('test:required');
-            const hasTestExempt = labels.includes('test:exempt');
-            core.setOutput('test_required', hasTestRequired ? 'true' : 'false');
-            core.setOutput('test_exempt', hasTestExempt ? 'true' : 'false');
+            try {
+              const { data: issue } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+              const labels = issue.labels.map(l => l.name);
+              console.log(`Issue #${issueNumber} labels: ${labels.join(', ')}`);
+              const hasTestRequired = labels.includes('test:required');
+              const hasTestExempt = labels.includes('test:exempt');
+              core.setOutput('test_required', hasTestRequired ? 'true' : 'false');
+              core.setOutput('test_exempt', hasTestExempt ? 'true' : 'false');
+            } catch (error) {
+              if (error.status === 404) {
+                console.log(`Issue #${issueNumber} not found in this repo — treating as no linked issue (likely a cross-repo reference or date digits in branch name).`);
+                core.setOutput('test_required', 'false');
+                core.setOutput('test_exempt', 'false');
+                return;
+              }
+              throw error;
+            }
 
       - name: Check for test file changes
         id: check-tests

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,11 +1,26 @@
 import { defineCollection, z } from 'astro:content'
 import { glob } from 'astro/loaders'
 
+// Reject article/log `date:` values stamped beyond today in the project's
+// canonical timezone (America/Phoenix). Pinning to a fixed TZ keeps validation
+// deterministic regardless of where `npm run build` runs (CI is UTC; agents
+// draft from a mix of Pacific, Arizona, and UTC machines). Catches the UTC
+// date-stamp bug class observed on 2026-04-22 where six articles drafted at
+// 20:13 PDT (03:13 UTC next day) were stamped with tomorrow's date.
+const notInFuturePhoenix = (d: Date) => {
+  const todayPhx = new Date().toLocaleDateString('en-CA', {
+    timeZone: 'America/Phoenix',
+  })
+  const dStr = d.toISOString().split('T')[0]
+  return dStr <= todayPhx
+}
+const futureDateMessage = 'date must not be in the future (America/Phoenix)'
+
 const articles = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/articles' }),
   schema: z.object({
     title: z.string(),
-    date: z.coerce.date(),
+    date: z.coerce.date().refine(notInFuturePhoenix, { message: futureDateMessage }),
     description: z.string().max(160),
     author: z.string().default('Venture Crane'),
     tags: z.array(z.string()).default([]),
@@ -20,7 +35,7 @@ const logs = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/logs' }),
   schema: z.object({
     title: z.string(),
-    date: z.coerce.date(),
+    date: z.coerce.date().refine(notInFuturePhoenix, { message: futureDateMessage }),
     tags: z.array(z.string()).default([]),
     draft: z.boolean().default(false),
     shipped: z.string().optional(),


### PR DESCRIPTION
## Summary

Resolves two independent failure modes in the content-PR pipeline that surfaced together during the 2026-04-22 content sprint.

### Fix 1: test-required.yml crashes on branch names containing digits

The branch-name extractor `branchName.match(/(\d+)/)` matches any digit run. Our standard branch-naming convention includes dates (`fix/article-dates-2026-04-22`), so every content PR hit this — the workflow extracted "2026" as an issue number, called `github.rest.issues.get(2026)`, 404'd, and crashed with an unhandled promise rejection. Affected 4 of 6 PRs on the 2026-04-22 sprint and blocked PR #103.

**Fix:** Add `#` anchor to the branch regex (symmetric with body extractor) + wrap `issues.get()` in try/catch that treats 404 as "no linked issue." Cross-repo `#N` references in PR bodies also stop crashing the workflow.

### Fix 2: Content schema accepts future-dated articles

`content.config.ts` used bare `z.coerce.date()`. Six articles last sprint got stamped with tomorrow's date because the drafting agents used `new Date().toISOString().split('T')[0]` (UTC) near the UTC-midnight flip. No validator caught it.

**Fix:** Add `.refine()` to article and log `date:` schemas that rejects any date beyond today in America/Phoenix. Pinned TZ keeps validation deterministic regardless of CI region.

### Why not paths-ignore?

Considered `paths-ignore: ['src/content/**']` on test-required.yml, dropped after critique: the two changes above already handle both observed failure modes, and paths-ignore is a GitHub Actions feature that only skips workflows when *all* changed paths match — doesn't create a gate-bypass for mixed PRs, but also doesn't add correctness over the two fixes. Keeping the change set tight.

## Test plan

- [x] Locally poisoned `src/content/articles/hello-world.md` with `date: 2099-01-01`; `npm run build` failed with clear message: `date must not be in the future (America/Phoenix)`
- [x] Restored real date; `npm run build` succeeded (65 pages, 6016 words indexed)
- [ ] CI green on this PR
- [ ] `check-test-required` no longer crashes on this PR (branch has digits only in `content/articles/*` paths of previous commits, not in our new branch name `ci/content-pr-hardening`)

## Rollback

Revert commit. Pre-existing `z.coerce.date()` and pre-fix regex restore unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)