### PR TITLE
chore(content): editorial fixes on recently-merged articles

### DIFF
--- a/src/content/articles/cross-venture-friction-to-fleet-rubric.md
+++ b/src/content/articles/cross-venture-friction-to-fleet-rubric.md
@@ -19,7 +19,7 @@ Diagnosing the friction surfaced three independent causes. Fixing them produced 
 
 The agent was hitting the wall repeatedly because three separate systems were contributing:
 
-**Branch protection `strict=true`.** When `required_status_checks.strict` is `true`, any time `main` moves, the PR's checks have to run again after another rebase. A dry run against the live org showed 6 of 7 venture repos enforcing this via a GitHub ruleset - not classic branch protection, rulesets. That's a fleet-wide tax paid on every PR in every active repo.
+**Branch protection `strict=true`.** When `required_status_checks.strict` is `true`, any time `main` moves, the PR's checks have to run again after another rebase. A dry run against the live org showed most venture repos enforcing this via a GitHub ruleset - not classic branch protection, rulesets. That's a fleet-wide tax paid on every PR in every active repo.
 
 **Bare `--force` warnings conflated with `--force-with-lease`.** The warning text in the guardrails didn't distinguish the two operations. `--force-with-lease` is safe - it fails if the remote has diverged since you last fetched. Bare `--force` is not safe - it overwrites unconditionally. The agent was reading the force-push warning and pausing even on `--force-with-lease` flows.
 
@@ -57,7 +57,7 @@ Hard blocks survived unchanged: bare `--force`, force-push to `main`, `reset --h
 
 A new `scripts/fleet-branch-protection.sh` handles both the classic-protection PATCH path and the rulesets PUT path. The script defaults to dry-run; `--apply` requires an explicit flag.
 
-Dry-run output against the live org confirmed the 6-repo scope. The canonical branch protection JSON was updated to set `strict=false`. The script wires into new-venture setup so future ventures inherit the profile automatically.
+Dry-run output against the live org confirmed the affected repos. The canonical branch protection JSON was updated to set `strict=false`. The script wires into new-venture setup so future ventures inherit the profile automatically.
 
 The apply step is Captain-confirmed because it modifies shared infrastructure across production repos. The risk accepted: with `strict=false`, two PRs that each pass CI on their own snapshots can both merge and break main if their changes conflict. The backstop is the fleet health audit's existing `ci-failed` finding type, which surfaces a red main within 24 hours. Velocity profile - Dependabot-dominated, low parallel concurrency - makes the failure mode rare enough to accept.
 


### PR DESCRIPTION
## Summary

Apply blocking fixes from the /edit-article editorial review on 7 articles that shipped without a proper editorial pass. One article had 2 blocking issues; the remaining 6 were clean.

Affected article: `cross-venture-friction-to-fleet-rubric.md`

**Blocking fixes applied (2):**

- Line 22: `"6 of 7 venture repos"` → `"most venture repos"` — specific fleet-size count, always blocking per terminology.md genericization rules
- Line 60: `"the 6-repo scope"` → `"the affected repos"` — same rule, second occurrence in same article

**Articles reviewed and cleared (no blocking issues):**
- `per-minute-session-activity-from-jsonl.md`
- `per-venture-cicd-alert-scoping.md`
- `validating-patterns-against-a-corpus.md`
- `plan-declared-workstreams.md`
- `parallel-session-worktree-isolation.md`
- `shipped-friday-retired-monday.md`

Advisory items (not auto-fixed) are listed in the review report.

## Test plan

- [x] `npm run verify` passes (0 errors, 0 warnings)
- [x] Both fixes are mechanical find-and-replace against exact quoted text
- [x] No prose restructuring, no content changes beyond the genericization fixes
- [x] Fact-checker pass deferred (not in scope for this follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)