### PR TITLE
chore(content): genericize client/prospect language in kill-discipline article

### DIFF
--- a/src/content/articles/shipped-friday-retired-monday.md
+++ b/src/content/articles/shipped-friday-retired-monday.md
@@ -1,7 +1,7 @@
 ---
 title: 'Shipped Friday, retired Monday: kill-discipline in four days'
 date: 2026-05-05
-description: 'A Phase 1 feature shipped end-to-end Friday. Monday a P0 client-portal bug closed it. Four days from launch to clean removal.'
+description: 'A Phase 1 feature shipped end-to-end Friday. Monday a P0 portal bug closed it. Four days from launch to clean removal.'
 author: 'Venture Crane'
 tags: ['agent-operations', 'kill-discipline', 'shipping']
 draft: false
@@ -11,13 +11,13 @@ We published a piece on kill-discipline as a practice - when to stop, how to esc
 
 ## What shipped Friday
 
-Four PRs merged in a single Claude Code session. A doctrine note capturing the architectural decision. A worker pipeline that drove the feature's analysis step. A durable workflow migration that wrapped that analysis in retry-and-resume. And a prospect-facing portal handoff with a magic-link email. The feature flag flipped live by May 1.
+Four PRs merged in a single Claude Code session. A doctrine note capturing the architectural decision. A worker pipeline that drove the feature's analysis step. A durable workflow migration that wrapped that analysis in retry-and-resume. And a user-facing portal handoff with a magic-link email. The feature flag flipped live by May 1.
 
 That is an end-to-end Phase 1 surface, shipped from a single approved plan in one session.
 
 ## The bug
 
-Over the weekend, the feature accumulated a P0 bug. A returning prospect followed an orphaned browser tab from a prior context and landed on a black "Not Found" page. The feature had assumed every visitor arrived with an active session context. That assumption held for new visitors. It didn't hold for returning visitors with stale tabs. The Captain saw the broken state on a Monday morning client visit - not from monitoring, from looking at the screen.
+Over the weekend, the feature accumulated a P0 bug. A returning user followed an orphaned browser tab from a prior context and landed on a black "Not Found" page. The feature had assumed every visitor arrived with an active session context. That assumption held for new visitors. It didn't hold for returning visitors with stale tabs. The Captain saw the broken state on Monday morning while reviewing the live site - not from monitoring, from looking at the screen.
 
 The design assumption was wrong. The surface area was small enough to read immediately. The decision took about a minute.
 
@@ -43,7 +43,7 @@ The asymmetry most teams live with runs the other direction: features cost more 
 
 ## The lesson in the bug
 
-The P0 bug was a design assumption that didn't hold under a real usage pattern. The Captain caught it from a live client visit, not from an alert. That is a fair criticism of the monitoring posture - the assumption should have been caught by an end-to-end test that modeled returning visitors with stale tabs, not by a client visit.
+The P0 bug was a design assumption that didn't hold under a real usage pattern. The Captain caught it from production use, not from an alert. That is a fair criticism of the monitoring posture - the assumption should have been caught by an end-to-end test that modeled returning visitors with stale tabs, not by hand inspection of the live site.
 
 The four-day window is not the lesson. The lesson is what made the four-day window possible: a bounded plan, separable architecture, and a team structure where retirement carries no political weight. Those three things apply to any feature at any stage. The four days just made them visible.
 


### PR DESCRIPTION
## Summary

Resolves the editorial advisory left over from PR #128 on `shipped-friday-retired-monday.md`:

The combination of "client visit" + "prospect-facing portal" + "returning prospect" narrowed venture identity to B2B services consulting (the stealth posture this article was meant to genericize). Replaced with neutral SaaS UX language that describes the same pattern without the positioning tell:

- "client-portal bug" → "portal bug" (description)
- "prospect-facing portal" → "user-facing portal"
- "returning prospect" → "returning user"
- "Monday morning client visit" → "Monday morning while reviewing the live site"
- "live client visit" → "production use"
- "by a client visit" → "by hand inspection of the live site"

## Test plan

- [x] `npm run verify` passes
- [x] No remaining "client" or "prospect" tokens in the article
- [x] Narrative intact: kill-discipline lesson, four-day arc, three structural enablers (bounded plan, separable architecture, no political cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)