### PR TITLE
chore: sync portfolio data from review 2026-05-05

### DIFF
--- a/src/data/ventures.ts
+++ b/src/data/ventures.ts
@@ -9,7 +9,7 @@ export interface Venture {
   started?: string
 }
 
-export const lastReviewed = '2026-02-23'
+export const lastReviewed = '2026-05-05'
 
 export const ventures: Venture[] = []
 


### PR DESCRIPTION
## Summary

- Bumps `lastReviewed` from 2026-02-23 → 2026-05-05 to match the upstream portfolio review in crane-console.
- `ventures` array stays empty — all entries in `config/ventures.json` still have `showInPortfolio: false`.

## Companion PR

- venturecrane/crane-console#TBD (chore: portfolio review 2026-05-05)

## Test plan

- [ ] CI green (typecheck/format/lint/build)
- [ ] Static site builds without changes to portfolio page

🤖 Generated with [Claude Code](https://claude.com/claude-code)