### PR TITLE
docs(agents): add AGENTS.md + surface coding-standards.md in CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+Instructions for AI agents (Codex CLI) working in this repository.
+
+## Repository
+
+venturecrane/vc-web - Venture Crane marketing site (Astro 5 + Tailwind, deployed to Cloudflare Pages).
+
+## Automatic Session Start
+
+When you begin a session, immediately do these in order before any work:
+
+1. Call `crane_preflight` (no arguments) - validates environment.
+2. Call `crane_sos` with `venture: "vc"` - initializes session, shows P0 issues, cadence briefing, active sessions.
+3. Read `CLAUDE.md` at the repo root - canonical Instruction Modules table (coding standards, guardrails, secrets, tooling, PR workflow, etc.).
+4. Fetch `crane_doc('global', 'coding-standards.md')` before editing any TypeScript or JavaScript.
+
+Do not start any work until preflight + sos succeed and CLAUDE.md is loaded. If preflight fails, show the error and stop.
+
+## Coding Standards
+
+All code edits MUST follow the Venture Crane portfolio coding standard, fetched via `crane_doc('global', 'coding-standards.md')`. Key directives that apply on every change:
+
+- Parse external inputs with Zod; never `as` cast at trust boundaries.
+- No floating Promises; explicitly `await` or attach a `.catch`.
+- No module-level state in Cloudflare Workers (per-isolate state leaks across requests).
+- File/function ceilings: 500 lines/file, 75 lines/function, complexity 15, depth 4, params 5.
+- No default exports outside framework-required positions (Astro pages, Next.js App Router files, Workers entry).
+- Fetch the global doc for the full 12 directives with good/bad examples and per-stack notes.
+
+Mechanical enforcement: vc-web's `eslint.config.js` inlines the portfolio rule set. `npm run lint` and CI fail on violations. The standard is also published as `@venturecrane/eslint-config` (GitHub Packages) but vc-web deliberately inlines rather than depending on the package; the eslint config header documents this choice.
+
+## Enterprise Rules
+
+- All changes go through PRs. Never push directly to main.
+- Work only on issues assigned to the current venture context (vc).
+- If you detect scope drift (working on a different repo than session context), stop and verify with the user.
+- All GitHub issues created this session must target `venturecrane/vc-web`.
+- When encountering errors, fix root causes - not symptoms.
+
+## Codex Environment
+
+Codex strips `KEY`/`SECRET`/`TOKEN` vars from all subprocess environments (shell commands and MCP servers). The `crane` launcher configures `shell_environment_policy.ignore_default_excludes` and MCP `env_vars` to whitelist the vars agents need.
+
+## Reference
+
+CLAUDE.md (loaded at session start per step 3 above) contains the full Instruction Modules table covering environment variables, QA grades, secrets management, git authority, and per-domain runbooks. Fetch any module on demand via `crane_doc('global', '<module>')`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,13 @@ Do not start any work until both calls succeed.
 Detailed domain instructions stored as on-demand documents.
 Fetch the relevant module when working in that domain.
 
-| Module              | Key Rule (always applies)                                                    | Fetch for details                          |
-| ------------------- | ---------------------------------------------------------------------------- | ------------------------------------------ |
-| `secrets.md`        | Verify secret VALUES, not just key existence                                 | Infisical, vault, API keys, GitHub App     |
-| `content-policy.md` | Never auto-save to VCMS; agents ARE the voice                                | VCMS tags, storage rules, editorial, style |
-| `team-workflow.md`  | All changes through PRs; never push to main                                  | Full workflow, escalation triggers         |
-| `fleet-ops.md`      | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh | SSH, machines, Tailscale, macOS            |
+| Module                | Key Rule (always applies)                                                                                                               | Fetch for details                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `coding-standards.md` | Parse external inputs (never cast); no floating Promises; no module-level state in Workers; 500/75/15 file/function/complexity ceilings | Portable TypeScript directives, agent-context arithmetic, per-stack notes |
+| `secrets.md`          | Verify secret VALUES, not just key existence                                                                                            | Infisical, vault, API keys, GitHub App                                    |
+| `content-policy.md`   | Never auto-save to VCMS; agents ARE the voice                                                                                           | VCMS tags, storage rules, editorial, style                                |
+| `team-workflow.md`    | All changes through PRs; never push to main                                                                                             | Full workflow, escalation triggers                                        |
+| `fleet-ops.md`        | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh                                                            | SSH, machines, Tailscale, macOS                                           |
 
 Fetch with: `crane_doc('global', '<module>')`
 


### PR DESCRIPTION
## Summary

Closes the documentation gap around the Venture Crane portfolio coding standard. vc-web's `eslint.config.js` already inlines the rule set, but no doc surface tells agents (Codex or Claude Code) about the standard. This PR adds AGENTS.md and surfaces `coding-standards.md` in the CLAUDE.md Instruction Modules table.

Companion to venturecrane/crane-console#884.

## Changes

- **New AGENTS.md** — Codex CLI's instruction file at the repo root. Session-start now requires reading CLAUDE.md and fetching `crane_doc('global', 'coding-standards.md')` before editing any TypeScript or JavaScript. Includes a "Coding Standards" section naming the standard and the five directives that bite hardest in agent code.
- **CLAUDE.md Instruction Modules row** — adds `coding-standards.md` to the existing table so Claude Code agents see the same pointer.

## Linked issue

None — initiative-level rollout following venturecrane/crane-console PR #864.

## Test plan

- [x] `npx prettier --check AGENTS.md CLAUDE.md` passes
- [x] `npm run lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)