### PR TITLE
content: stagger publish dates across May 20-30

### DIFF
--- a/src/content/articles/enforce-secrets-at-the-boundary.md
+++ b/src/content/articles/enforce-secrets-at-the-boundary.md
@@ -1,6 +1,6 @@
 ---
 title: 'You Cannot Instruct an Agent Not to Leak'
-date: 2026-05-30
+date: 2026-05-27
 description: 'Memory notes told the agent not to echo secret values. It did anyway, twice. The fix was structural enforcement at the tool boundary, not better instructions.'
 author: 'Venture Crane'
 tags: ['secrets', 'infrastructure', 'agent-workflow', 'security']

--- a/src/content/articles/per-customer-observability-agent-fleet.md
+++ b/src/content/articles/per-customer-observability-agent-fleet.md
@@ -1,6 +1,6 @@
 ---
 title: 'Observability That Is Born and Dies With the Tenant'
-date: 2026-05-30
+date: 2026-05-25
 description: 'When every customer runs an isolated agent deployment, monitoring becomes per-tenant and lifecycle-aware. The heartbeat, webhook, and fleet stack we wired.'
 author: 'Venture Crane'
 tags: ['observability', 'infrastructure', 'monitoring', 'cloudflare-workers']

--- a/src/content/articles/retiring-a-fork-that-stopped-earning.md
+++ b/src/content/articles/retiring-a-fork-that-stopped-earning.md
@@ -1,6 +1,6 @@
 ---
 title: 'Retiring a Fork That Stopped Earning Its Keep'
-date: 2026-05-30
+date: 2026-05-23
 description: 'A dependency you control "for safety" can quietly become pure cost. We audited a fork from first principles and found the safe move was to delete it.'
 author: 'Venture Crane'
 tags: ['architecture', 'infrastructure', 'dependencies', 'process']

--- a/src/content/articles/strangler-fig-auth-migration.md
+++ b/src/content/articles/strangler-fig-auth-migration.md
@@ -1,6 +1,6 @@
 ---
 title: 'Collapsing Two Auth Systems Into One Without Rewriting 73 Call Sites'
-date: 2026-05-30
+date: 2026-05-21
 description: 'A session shim that rebuilds the old session shape from a new identity provider lets you swap auth under dozens of call sites without a big-bang rewrite.'
 author: 'Venture Crane'
 tags: ['auth', 'architecture', 'migration', 'clerk']

--- a/src/content/logs/2026-05-20-token-registry-rotation.md
+++ b/src/content/logs/2026-05-20-token-registry-rotation.md
@@ -1,6 +1,6 @@
 ---
 title: 'Writing down every token before one of them broke'
-date: 2026-05-30
+date: 2026-05-20
 tags: ['security', 'infrastructure', 'documentation']
 draft: false
 ---

--- a/src/content/logs/2026-05-22-mcp-first-migration.md
+++ b/src/content/logs/2026-05-22-mcp-first-migration.md
@@ -1,6 +1,6 @@
 ---
 title: 'Going vendor-direct MCP first and retiring an aggregator default'
-date: 2026-05-30
+date: 2026-05-22
 tags: ['ai-employee', 'mcp', 'integrations', 'architecture']
 draft: false
 ---

--- a/src/content/logs/2026-05-24-execute-code-skill-refactor.md
+++ b/src/content/logs/2026-05-24-execute-code-skill-refactor.md
@@ -1,6 +1,6 @@
 ---
 title: 'Moving agent fetch loops into a code-execution primitive'
-date: 2026-05-30
+date: 2026-05-24
 tags: ['ai-employee', 'agents', 'tokens', 'reliability']
 draft: false
 ---

--- a/src/content/logs/2026-05-26-claude-ai-venture-binding.md
+++ b/src/content/logs/2026-05-26-claude-ai-venture-binding.md
@@ -1,6 +1,6 @@
 ---
 title: 'Binding claude.ai projects to the right venture'
-date: 2026-05-30
+date: 2026-05-26
 tags: ['claude-ai', 'mcp', 'infrastructure']
 draft: false
 ---

--- a/src/content/logs/2026-05-28-secret-leak-enforcement.md
+++ b/src/content/logs/2026-05-28-secret-leak-enforcement.md
@@ -1,6 +1,6 @@
 ---
 title: 'Moving secret-leak prevention outside the agent'
-date: 2026-05-30
+date: 2026-05-28
 tags: ['security', 'infrastructure', 'agents']
 draft: false
 ---

--- a/src/content/logs/2026-05-29-ai-employee-build-arc.md
+++ b/src/content/logs/2026-05-29-ai-employee-build-arc.md
@@ -1,6 +1,6 @@
 ---
 title: 'Hardening an AI employee into a config-governed, safety-gated system'
-date: 2026-05-30
+date: 2026-05-29
 tags: ['ai-employee', 'architecture', 'safety', 'config']
 draft: false
 ---


### PR DESCRIPTION
Spreads the 11 pieces from #140/#142 (all dated 2026-05-30) one per day across May 20-30, articles and logs interleaved, harness-is-the-product kept at 05-30 as the flagship.

| Date | Piece | Type |
|---|---|---|
| 05-20 | token-registry-rotation | log |
| 05-21 | strangler-fig-auth-migration | article |
| 05-22 | mcp-first-migration | log |
| 05-23 | retiring-a-fork-that-stopped-earning | article |
| 05-24 | execute-code-skill-refactor | log |
| 05-25 | per-customer-observability-agent-fleet | article |
| 05-26 | claude-ai-venture-binding | log |
| 05-27 | enforce-secrets-at-the-boundary | article |
| 05-28 | secret-leak-enforcement | log |
| 05-29 | ai-employee-build-arc | log |
| 05-30 | harness-is-the-product | article |

**Log URLs change** (date is in the log slug): the 6 logs are `git mv`-renamed to their new dates; old `/log/2026-05-30-*/` URLs will 404. No redirects (hours-old, no external links). Article URLs unchanged (frontmatter-only date).

astro build green (204 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)