### PR TITLE
content: cross-link agent-context article ↔ explainer video

### DIFF
--- a/src/content/articles/agent-context-management-system.md
+++ b/src/content/articles/agent-context-management-system.md
@@ -4,6 +4,7 @@ date: 2026-02-14
 description: 'Building centralized context management so AI agents start every session with the right knowledge.'
 author: 'Venture Crane'
 tags: ['agent-context', 'mcp', 'infrastructure']
+updatedDate: 2026-06-01
 draft: false
 ---
 
@@ -20,6 +21,8 @@ We built a centralized context management system to solve this. It gives every a
 - **Work queue visibility** - GitHub issues by priority and status
 
 The system is designed for a small team (1-5 humans) running multiple AI agent sessions in parallel across a fleet of development machines.
+
+> 🎥 **Prefer the 80-second version?** Watch the explainer: [Every AI agent session starts cold — here's how we fixed it](https://youtu.be/2D3PhQdEINs).
 
 ---
 


### PR DESCRIPTION
Two-way cross-promotion between the **agent context management** article and the new YouTube explainer.

## Change
- Adds a callout near the top of `agent-context-management-system.md` linking to the explainer: https://youtu.be/2D3PhQdEINs
- Stamps `updatedDate: 2026-06-01`

## Context
Companion to the video, which now links back to this article in its description (two-way cross-promo). The video is the 80-second narrated version of this write-up, published to the new **Venture Crane** YouTube channel (@venturecrane).

## Verification
- `npm run verify` green locally (typecheck + format:check + lint + astro build; content schema validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)