### PR TITLE
fix(settings): drop invalid mcp__claude_ai_* allow rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,8 +13,7 @@
       "Task",
       "NotebookEdit",
       "mcp__crane__*",
-      "mcp__apple-notes__*",
-      "mcp__claude_ai_*"
+      "mcp__apple-notes__*"
     ]
   }
 }


### PR DESCRIPTION
## What

Remove the invalid `mcp__claude_ai_*` rule from `permissions.allow` in `.claude/settings.json`.

## Why

Claude Code `2.1.x` tightened allow-rule validation. A wildcard in the **server-name** slot is no longer accepted — allow rules permit a glob only in the **tool** slot after a literal `mcp__<server>__` prefix. The CLI now skips the rule and shows a startup **Settings Warning** at every `crane <venture>` launch.

The file did not change (rule dates to the repo's initial scaffolding); the CLI validator did. The rule was always a no-op anyway — a server-position glob cannot match real tool names like `mcp__claude_ai_Gmail__send` — so removing it changes **no effective permission**. End state matches `crane-console`, which only carries the `crane_context` rule in `deny`.

## Verification

- `jq` confirms the file still parses as valid JSON.
- Rule is absent from `permissions.allow`.
- Only `.claude/settings.json` is touched.

QA: A (mechanical config fix, no runtime behavior change)