### PR TITLE
fix(seo): remove doubled site-name suffix in page titles

### DIFF
--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -63,7 +63,7 @@ const articleSchema = {
 ---
 
 <Base
-  title={`${title} | Venture Crane`}
+  title={title}
   description={description}
   jsonLd={articleSchema}
   articleMeta={{

--- a/src/layouts/Log.astro
+++ b/src/layouts/Log.astro
@@ -38,7 +38,7 @@ const blogPostingSchema = {
 }
 ---
 
-<Base title={`${title} | Venture Crane`} jsonLd={blogPostingSchema}>
+<Base title={title} jsonLd={blogPostingSchema}>
   <div
     class="rounded-lg bg-surface p-6 sm:p-8"
     data-pagefind-body

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,7 +2,7 @@
 import Base from '../layouts/Base.astro'
 ---
 
-<Base title="Page Not Found | Venture Crane">
+<Base title="Page Not Found">
   <div class="py-16 text-center sm:py-24">
     <h1 class="mb-4">Page not found</h1>
     <p class="mx-auto mb-8 max-w-lg text-lg text-vc-text-muted">

--- a/src/pages/articles/[...page].astro
+++ b/src/pages/articles/[...page].astro
@@ -18,7 +18,7 @@ type Props = InferGetStaticPropsType<typeof getStaticPaths>
 const { page } = Astro.props as Props
 ---
 
-<Base title="Articles | Venture Crane" description="Engineering articles from Venture Crane.">
+<Base title="Articles" description="Engineering articles from Venture Crane.">
   <h1 class="mb-8">Articles</h1>
   {
     page.data.length > 0 ? (

--- a/src/pages/log/[...page].astro
+++ b/src/pages/log/[...page].astro
@@ -18,10 +18,7 @@ type Props = InferGetStaticPropsType<typeof getStaticPaths>
 const { page } = Astro.props as Props
 ---
 
-<Base
-  title="Ship Log | Venture Crane"
-  description="Ship log from the Venture Crane development lab."
->
+<Base title="Ship Log" description="Ship log from the Venture Crane development lab.">
   <h1 class="mb-8">Ship Log</h1>
   {
     page.data.length > 0 ? (

--- a/src/pages/open-problems.astro
+++ b/src/pages/open-problems.astro
@@ -11,7 +11,7 @@ const formatDate = (d: Date) =>
 ---
 
 <Base
-  title="Open Problems | Venture Crane"
+  title="Open Problems"
   description="Hard problems in AI-native development we haven't solved yet. Current experiments and unsolved challenges."
 >
   <div class="rounded-lg bg-surface p-6 sm:p-8">

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -22,7 +22,7 @@ const formattedDate = reviewDate.toLocaleDateString('en-US', { month: 'long', ye
 ---
 
 <Base
-  title="Active Ventures | Venture Crane"
+  title="Active Ventures"
   description="Products being built with AI agents under human direction."
 >
   <h1 class="mb-2">Active Ventures</h1>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -10,7 +10,7 @@ const formatDate = (d: Date) =>
   d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 ---
 
-<Base title="Privacy Policy | Venture Crane">
+<Base title="Privacy Policy">
   <div class="rounded-lg bg-surface p-6 sm:p-8">
     <div class="vc-prose">
       <Content />

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -2,7 +2,7 @@
 import Base from '../layouts/Base.astro'
 ---
 
-<Base title="Search | Venture Crane" description="Search articles and ship logs.">
+<Base title="Search" description="Search articles and ship logs.">
   <h1 class="mb-8">Search</h1>
   <div id="search"></div>
   <link href="/pagefind/pagefind-ui.css" rel="stylesheet" />

--- a/src/pages/start-here.astro
+++ b/src/pages/start-here.astro
@@ -12,7 +12,7 @@ const formatDate = (d: Date) =>
 ---
 
 <Base
-  title="Start Here | Venture Crane"
+  title="Start Here"
   description="Where to start reading about AI-native development operations. Curated paths for solo founders, teams adopting AI tools, and anyone exploring the discipline."
 >
   <div class="rounded-lg bg-surface p-6 sm:p-8">

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -39,7 +39,7 @@ const { tag, articles, logs } = Astro.props
 const venture = ventures.find((v) => v.contentTag === tag)
 ---
 
-<Base title={`${tag} | Venture Crane`} description={`Content tagged "${tag}".`}>
+<Base title={tag} description={`Content tagged "${tag}".`}>
   <h1 class="mb-8">{tag}</h1>
 
   {venture && <p class="mb-8 text-lg text-vc-text-muted">{venture.description}</p>}

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -22,7 +22,7 @@ for (const log of logs) {
 const sortedTags = [...tagCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]))
 ---
 
-<Base title="Tags | Venture Crane" description="Browse content by topic.">
+<Base title="Tags" description="Browse content by topic.">
   <h1 class="mb-8">Tags</h1>
   {
     sortedTags.length > 0 ? (

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -10,7 +10,7 @@ const formatDate = (d: Date) =>
   d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 ---
 
-<Base title="Terms of Use | Venture Crane">
+<Base title="Terms of Use">
   <div class="rounded-lg bg-surface p-6 sm:p-8">
     <div class="vc-prose">
       <Content />

--- a/src/pages/the-system.astro
+++ b/src/pages/the-system.astro
@@ -11,7 +11,7 @@ const formatDate = (d: Date) =>
 ---
 
 <Base
-  title="The System | Venture Crane"
+  title="The System"
   description="The operating system behind Venture Crane. Named beliefs, core primitives, and the session lifecycle that makes AI-native development reliable."
 >
   <div class="rounded-lg bg-surface p-6 sm:p-8">


### PR DESCRIPTION
Every non-home page rendered a doubled title - `... | Venture Crane | Venture Crane` - because `Base.astro` appends the site name AND 14 callers pre-appended it too.

Fix: strip the redundant suffix from all callers so they pass bare titles (the contract `contact.astro` already followed). `Base.astro` keeps the single append; the homepage stays special-cased. OG/Twitter titles are now clean too.

Verified: `npm run verify` green; rendered `<title>` tags carry exactly one suffix; zero doubled titles in `dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
