### PR TITLE
content: four articles from the late-June AI-employee sprint (drafts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,9 +123,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -141,9 +138,6 @@
       "integrity": "sha512-O3e2CbN4yTsRguWYNnRd0p5YQ0H3fb7KpcR0W4R319q/gq5B1pJ7eqNbiO3b8g2AuiEcRTiUz5jeGT9j69cxOQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -161,9 +155,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -179,9 +170,6 @@
       "integrity": "sha512-vIiEvOwrJfHZMaTmqUCrFTIwMYL0+PD3Rvy7kFDQgERyx3zhaw8CPa01MCCqa+/sj344BGrXKZ6ti37SgNLMhw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -497,9 +485,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -511,9 +496,6 @@
       "integrity": "sha512-wRaKSHCRXwzAZwlieCiv3u8pWEE2t9FmhZ0X59YZvHCGin56YUBOTyEQqSOrRfXs6fhUb8ylprisGYJC6J8mFQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "optional": true,
       "os": [
@@ -527,9 +509,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -541,9 +520,6 @@
       "integrity": "sha512-ZSu+a07Efn8sOeA1k9ZM9CO9J3sAeG37Sf2YYxi/unFGgkFe+Y8MHDQlUNtngpC8pkYIjkojkLFT6v1yiHNxOg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "optional": true,
       "os": [
@@ -2192,9 +2168,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2210,9 +2183,6 @@
       "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2230,9 +2200,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2248,9 +2215,6 @@
       "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2268,9 +2232,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2286,9 +2247,6 @@
       "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4841,9 +4799,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4863,9 +4818,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4887,9 +4839,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4909,9 +4858,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -7502,9 +7448,19 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -7665,14 +7621,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"

--- a/src/content/articles/access-control-shared-ai-employee.md
+++ b/src/content/articles/access-control-shared-ai-employee.md
@@ -1,0 +1,66 @@
+---
+title: 'The Grant Table Is the Kill Switch: Access Control for a Shared AI Employee'
+date: 2026-07-01
+description: 'Several people share one autonomous agent: the identity provider proves who they are, but a grant read live on every request decides whether they still get in.'
+author: 'Venture Crane'
+tags: ['security', 'agents', 'architecture', 'access-control', 'ai-employee']
+draft: true
+---
+
+An identity provider tells you who someone is. It does not tell you whether they should still have access. Those are two separate decisions, and the most common way to get access control wrong is to let the first one stand in for the second. This came up while wiring a chat connector for an AI employee product, where several people at a customer firm share one autonomous agent, and the question that forced the design was not "how does a person sign in" but "how is that person's access severed the day they leave."
+
+## The shape of the problem
+
+The product runs one isolated deployment per customer. Inside that deployment lives a single autonomous agent that does real work on the firm's behalf, and the firm's own staff reach it through a chat connector - a remote MCP server exposed to Claude as a custom connector. The agent is shared. Five people at a professional-services firm might all direct the same agent, and each of them needs to be granted access on their first day and cut off on their last.
+
+Two facts about the plumbing constrained everything that followed.
+
+First, a Claude custom connector authenticates one of two ways: fully authless, or per-user OAuth with mandatory user consent. There is no connector-level shared machine credential and no machine-to-machine path. Authless is a non-starter for a connector that reaches sensitive business data, so every firm connection is per-user OAuth. Each person who adds the connector goes through their own sign-in.
+
+Second, we use Clerk as the identity provider, and Clerk's OAuth access tokens are one-day JWTs whose refresh tokens never expire. Once a refresh token has been issued to a user, it can linger indefinitely. That is fine for a consumer app where the user owns their own account. It is a problem when the account belongs to an employee who might be terminated, and the token in their Claude client keeps minting fresh one-day access tokens long after they have walked out the door.
+
+## The token cannot be the gate
+
+Put those two facts together and the conclusion is forced: the token cannot be the thing that authorizes access, because we do not control its lifetime. A per-user OAuth token is proof that Clerk once verified this person's email. It is not proof that the firm still wants them talking to its agent. If we treat "holds a valid token" as "is allowed in," then revoking someone means somehow reaching into Clerk's token machinery and killing a credential that was designed never to expire. That is the wrong layer to fight at.
+
+The move is to stop asking the token to carry authorization at all. Login proves who. A separate grant decides whether, and until when. We keep those two jobs in two different systems: the identity provider owns login and token crypto, and our own grant table owns the allow decision.
+
+## The grant table is the gate, and the kill switch
+
+Authorization is a row. When a person is allowed to reach a customer's agent, there is a record for them in a grants table (`mcp_issued_grants`), and that row is read live on every single MCP request. Not cached at login, not baked into the token, not trusted from the session - read fresh, per call, against the authoritative store. The agent's configuration is already loaded live rather than snapshotted, and authorization rides the same posture.
+
+Because the grant, and not the Clerk token, is the gate, two properties fall out that a token-based design cannot offer.
+
+An explicit revoke cuts on the next call, within seconds. An administrator flips the row to revoked, the next request from that user reads the revoked state, and access is gone - regardless of the one-day JWT still sitting valid in their client, regardless of the refresh token that will never expire on its own. We do not need token introspection, opaque tokens, or a callback to the identity provider. The kill switch is a database write, and it is instant because the read is live. This is the central correctness property of the whole design, and the one thing that must never regress: the moment the token becomes the gate again, the kill switch stops working.
+
+Grants are bounded. Every row carries an `expires_at`, and it is never null. There is no "forever" grant. In the shipped build the TTL is clamped to a `[1, 90]` day window, and open-policy grants get a shorter ceiling still. A grant that lapses is not renewed silently; renewal is a fresh sign-in, which brings us to the second half of offboarding.
+
+## Offboarding rides the mailbox
+
+Sign-in is a Clerk email-link, or more precisely a one-time code delivered to the person's firm mailbox. No password, no key. The identity being proven is possession of the live firm email address. That choice does more than avoid password management: it hands offboarding to a system the firm already runs perfectly.
+
+When someone leaves, the firm disables their mailbox. That is an action every organization already takes on the last day, reliably, as part of a process that exists whether or not our product is in the picture. Because every grant is bounded and renewal requires a fresh email-link sign-in, a person whose mailbox has been killed cannot complete the re-auth when their grant lapses. Their access decays on its own inside the TTL window, with no action required from anyone on our side. Set the session lifetime to the grant TTL and that re-auth is forced at a known cadence.
+
+So there are two offboarding paths, and they are layered on purpose. The explicit admin revoke is the immediate, authoritative cut. The mailbox-possession lapse is the passive backstop that catches the case nobody remembered to revoke. We do not lean on the passive path as the primary control - the bounded `expires_at` plus the explicit revoke is the authoritative story, and the passive lapse is secondary until the token-lifetime assumptions behind it are verified empirically. But designing offboarding so it can happen without us carrying the burden is the point of routing identity through the firm's own mailbox.
+
+## Proven beats clever
+
+An earlier version of this design was more clever. The agent itself would mint a signed sign-in ticket and thread it into Claude's OAuth flow, so a firm could hand its people a one-click path without a mailbox round-trip. It was elegant. It was also a new, unproven seam with a spoofable inbound sender surface and a bearer-token-in-an-inbox risk, none of which the documented email-link path carries.
+
+We demoted the bespoke ticket to optional sugar and shipped on the identity provider's documented email-link login instead. The email-link path is a native sign-in strategy on the platform we already use - a configuration toggle, not a hand-rolled protocol. The transferable version of this: when a security-critical path can be built from a documented, already-proven primitive or from a bespoke mechanism you find pleasing, the bespoke mechanism has to earn its seam against the failure modes the proven path simply does not have. Ours could not, so it lost.
+
+## The agent is not a permission proxy
+
+One category error is worth naming because it is easy to back into. A shared agent authenticates to the firm's systems - its practice-management system, its document store - as one firm-level identity. It does not inherit each caller's individual permissions. When five people share the agent, they are not five scoped sub-identities; they are five people authorized to direct one identity that has the access it has.
+
+That means the grant table answers exactly one question - may this person reach this customer's agent at all - and it must not be mistaken for a per-user permission system that scopes what the agent will then do on their behalf. Conflating the two invites a false sense that the access model is also an authorization-scoping model. It is not. Fine-grained "who may ask the agent for what" is a separate obligation, and pretending the firm-level identity is a per-user proxy is how you end up believing you have controls you never built.
+
+## The transferable lesson
+
+If you run a shared autonomous agent that several people reach through their own authenticated sessions, do not let the identity provider's token be your access control. Let it prove identity, and nothing more. Put the allow decision in a table you own, read it live on every request, and make revoking a row the kill switch. Bound every grant with a real expiry and refuse the idea of a permanent one. Route identity through a credential the customer already de-provisions on offboarding - a mailbox is a good one - so access decays without you having to chase it. Prefer the documented sign-in primitive over the clever bespoke one. And keep the question the access table answers narrow: whether someone gets in is not the same as what the shared identity is then allowed to do.
+
+The token proves you were let in once. Whether you are still allowed is a different fact, and it has to live somewhere you can change in one write.
+
+---
+
+_We build isolated per-customer AI employees, with staff access brokered through a Claude custom connector (a remote MCP server) over per-user OAuth on Clerk, authorized by a live-read grant table with an immutable change ledger. This describes access-control work landed on 2026-06-27 (the grant table, live-read authorization, bounded TTLs, admin revoke, and issuance policy); the open-by-domain just-in-time grant path is built and tested but not the operating policy for the current pilot (which ships on allowlist), and the end-state cutover to a customer's own managed directory is staged, not shipped, and an earlier screening-attestation gate was removed as out of scope for a use-at-your-own-risk product._

--- a/src/content/articles/author-built-mcp-connectors.md
+++ b/src/content/articles/author-built-mcp-connectors.md
@@ -1,0 +1,58 @@
+---
+title: 'Bake Every Author-Built Connector In, Keep It Inert Until Bound'
+date: 2026-07-01
+description: 'When a vendor has no MCP server you author your own. The real decision is where that connector code lives: baked into one shared image, inert until bound.'
+author: 'Venture Crane'
+tags: ['architecture', 'mcp', 'agents', 'ai-employee']
+draft: true
+---
+
+We build an AI employee: an autonomous agent that does the connective front-desk work of a small business, and to do that job it has to bind to whatever systems of record its industry runs on. Most of those systems now expose a Model Context Protocol server, first-party or from a vetted community. You bind it as config, the agent's tools light up, and no code of yours ships to make that happen. Then you hit a vendor with no MCP server at all. The capability is real, the agent has to call it, and nobody has written the wrapper, so you write it yourself. That surfaces a question the connector strategy did not answer: where does the connector code you author physically live, and how does it reach only the machines that need it?
+
+The naive answer feels obvious and is wrong.
+
+## A connector that surfaces tools has to be an MCP server
+
+The first fork is not about location, it is about shape, and it is easy to get wrong because the runtime has two ways to run code you author. One is a plain command-line adapter, reached through a generic execute-code path: the agent shells out to it, passes arguments, reads output. The other is a stdio MCP server the agent speaks the protocol to.
+
+The distinction that matters: a command-line adapter does not surface tools. There is no bridge that turns its commands into callable tools the agent sees in its own tool list. It is a script the agent can run, not a capability the agent knows it has. An MCP server is the opposite: its whole job is to advertise tools over the protocol, so binding one makes those tools materialize into the agent's surface. The choice is forced by the capability. If the agent needs to read matters out of a practice-management system and write memos back against them as first-class tool calls, it has to be an MCP server. "When no acceptable MCP exists, build one" is the right rule, but "build one" has to mean build an MCP server, not a CLI, whenever the capability must surface tools. Naming that shape is the precondition for the location decision, because only a server has code that has to be installed somewhere and launched.
+
+## The distribution problem that does not exist
+
+The tempting answer to "where does it live" is to treat each author-built connector as its own shippable unit: a repository, a version pin, a release pipeline, installed onto a customer's machine only when that customer's config binds it. The code follows the binding, a machine carries a connector for exactly one reason, and the shared base image never bloats. The reasoning is fear of bloat: at ninety-five author-built connectors, a shared image carrying all of them makes every customer's base artifact haul ninety-four it never launches.
+
+It solves a problem nobody has, and two facts already true in the system show why. The first is a precedent sitting right next to the connectors: the entire skill catalog is baked into every image, and per-customer selection is pure config. No skill ships per-customer; the binding selects from what is already present. A customer whose persona enables three skills still carries the whole catalog on disk, and that has never been a problem, because dormant skills cost only the disk they sit on. The second is the activation rail. The materializer that turns bindings into runtime config launches an MCP server only when a config binding names it, so a baked-but-unbound server is not a running process. It is inert code on disk, never launched, holding no credentials, surfacing no tools.
+
+The per-customer-install model is therefore solving a distribution problem the inert-baked model already avoids for free, and it reintroduces the coupling the config model exists to prevent: if adding a connector for one customer means publishing and installing a unit, the connector's lifecycle becomes a per-machine operation you have to track. The skill catalog proved you do not need that. Selection is the binding, not the install.
+
+## Baked in, kept inert, activated on bind
+
+The corrected model is the one the skill catalog was already using. An author-built connector lives in the shared codebase as a stdio MCP server, built on a shared connector SDK, installed into its own isolated Python venv inside the one shared image. The image stays the single governed deploy unit. Every machine in the fleet carries every author-built connector, and carries almost all of them dormant.
+
+Dormant is the load-bearing word. A connector does nothing until a per-customer config binds it. On bind, the materializer launches that connector's server by its venv console-script path, its tools surface into that customer's agent, and that customer's credentials are injected. Present-but-inert on every machine, live on exactly the machines that asked for it. The posture is identical to a catalog skill no persona has enabled: shipped everywhere, active nowhere it was not selected.
+
+Adding a connector becomes an image change, like adding a skill: you add the server to the shared codebase, it rides the next reprovision, and it sits dormant until some customer's config activates it. No publish-and-pin step, no per-machine install to track, no separate release pipeline. The only cost is disk for inert code, paid once - the same bill the skill catalog has been paying without anyone noticing.
+
+## Governance stays hand-authored, the manifest is only an oracle
+
+Baking a connector into the shared image raises the obvious worry: does folding third-party tool surfaces into the governed artifact let a connector smuggle in authority? It does not, because trust is not something a connector can assert about itself.
+
+Every tool a connector surfaces gets an action class - what the agent is allowed to do with it - and those classes are hand-authored literal lines in the governance map, reviewed in the pull request that adds the connector. The connector ships a manifest that also declares its tools' intended classes, but that manifest is never a runtime input. It is a conformance oracle: a check run against the hand-authored map to catch drift between what the connector thinks its tools do and what the map actually grants. The map is authority; the manifest is a test fixture. A connector cannot self-certify by editing its own manifest, because the runtime never reads the manifest for permissions.
+
+The fail-closed default is what makes this safe rather than merely tidy. A tool no hand-authored line has classified does not default to allowed or to some inferred class; it fails closed to refused. Adding a connector to the image adds inert code and a set of tools denied by default until a human writes the literal lines that grant them, in a diff another human reviews. The trust surface is the reviewed map, not the shipped artifact.
+
+## Isolation runs end to end
+
+The last property is why none of this becomes a shared service. An author-built connector runs inside the customer's own isolated machine, launched as a stdio subprocess of that customer's agent, scoped to that customer's credentials. It is never a hosted connector service that every customer's agent calls.
+
+That distinction is the whole point of per-customer isolation. The firm's API token and the data flowing through the connector stay on the firm's own machine and never touch anyone else's. A single shared connector service, however convenient, would re-pool exactly the isolated data the per-customer model works to keep separate, and make one connector process a blast surface across every customer at once. Baked-and-inert does not weaken that: the connector code is shared on disk, but the running process, its credentials, and its data are not. Same image everywhere, isolated execution everywhere.
+
+## The transferable lesson
+
+When you productize an agent that must integrate with many third-party systems, the vendors without an MCP server force you to author your own, and the instinct is to treat each author-built connector as a shippable unit installed per customer. Resist it. That answer solves a distribution problem the inert-baked model already avoids: bake every author-built connector into the one shared, governed image, and keep it dormant until a per-customer binding activates it. Dormant code costs only disk. What you buy is a single deploy unit where adding a connector is an image change like adding a skill, not a per-machine install and not a coupling that makes one customer's new connector a change to the artifact every customer runs. Then hold the other two decisions separate from location: keep governance authority in a hand-authored map reviewed in the diff with the connector's manifest as a conformance check and never a runtime input, fail unclassified tools closed to refused, and run every connector inside the customer's isolated machine scoped to that customer's credentials. The mistake is letting where the code lives drag governance and isolation toward a shared service or a self-certifying artifact.
+
+The deferred option, if it is ever needed, is per-customer images carrying only the connectors a customer binds. That trade pays off only if baked connector count or image size ever makes the shared image too heavy to ship, and it costs the single-image trust surface to buy. Until weight actually demands it, one shared image with dormant connectors is lighter to reason about than a fleet of bespoke ones.
+
+---
+
+_We build a productized AI employee as isolated per-customer agent deployments, with third-party integrations bound through a per-customer config layer over a shared, pinned image. This describes an architecture decision landed in June 2026, corrected during implementation from a per-customer-installed model to baked-and-inert, with the first connector we had to author ourselves - a practice-management system with no first-party MCP - as its first instance._

--- a/src/content/articles/depth-at-altitude-adversarial-authoring.md
+++ b/src/content/articles/depth-at-altitude-adversarial-authoring.md
@@ -1,0 +1,40 @@
+---
+title: 'Template Gives You Consistency, Not Credibility'
+date: 2026-07-01
+description: 'Per-vertical content a practitioner respects cannot be stamped from one template. Depth at altitude takes serial authoring through an adversarial critique loop.'
+author: 'Venture Crane'
+tags: ['content', 'methodology', 'agent-operations']
+draft: true
+---
+
+A dozen vertical marketing pages for a productized AI service started as one template stamped a dozen times. Each page had the same sections, the same rhythm, the same reassuring verbs, and a different industry's nouns dropped into the slots. They were consistent. They were also generic, and generic is the one thing a domain practitioner detects on sight. So they were rebuilt, one industry at a time, each rewritten from template copy to the actual operational lifecycle of that industry, through an adversarial loop: draft, critique the draft as a skeptical practitioner from that field, rewrite against the critique. This is the account of why that work could not be batch-generated, and why doing it serially beat doing it fast.
+
+It is worth naming the tension up front. A companion piece on [a two-day parallel UI sweep](/articles/product-ui-parallel-sweep) argued that a large build becomes tractable when you land a shared abstraction first and fan out many agents onto it at once. That is true for surfaces built on a frozen seam. It is the wrong instinct for content that has to earn a practitioner's respect. We parallelized thirty UI pull requests in that build; we authored these vertical pages one at a time, on purpose. The difference is not scale. It is where the value lives.
+
+## The template trap is not the fork trap
+
+The [templating architecture piece](/articles/templating-ai-service-across-verticals) is about avoiding the fork: make a vertical a piece of data the core product reads, not a copy of the codebase. That solves a maintenance problem. It does not solve a credibility problem, and it is easy to assume it does. If the architecture lets one product carry a dozen verticals from one manifest, the marketing surface for each vertical feels like it should fall out of the same move: one page template, a dozen manifests, done.
+
+It does fall out that way. The result is a dozen pages that a practitioner reads as marketing. The trap here is not duplication cost. It is that a template propagates a shape, and the shape is exactly the part that carries no domain knowledge. A law page and an accounting page can share every heading and every transition and still both be wrong in the specific way that matters, because the specific thing that matters is not in the shape.
+
+## Altitude is the part the template cannot fill
+
+The rebuilt pages center on a lifecycle walk: one real stretch of the industry's core process, carried start to finish, each step in three lines - what the agent does, what the person does, what happens if the step stalls. Those three lines are a template, and a good one. It is a template for structure. It cannot supply the substance that goes in it, and the substance is where a practitioner decides whether the author understands the work.
+
+The accounting page is the clearest evidence, because the record of its correction survives in the source. The first draft had the agent deliver the e-file authorization and collect the signature in a plausible-sounding order. A critique in the voice of a veteran managing partner caught that the completed return must go to the client for review before the authorization is signed, and that transmission happens only after the signed authorization is in hand, because that is what the federal e-file rules require. The same pass corrected a records request the agent had been "soliciting" from a predecessor firm, when in that profession the client requests their own prior records. It separated tracking a firm-entered deadline from determining whether a return must be filed at all, because the second is professional judgment and the first is not. It de-titled the roles, because a sole practitioner and an enrolled agent are not a "partner" and a "preparer." And it collapsed three overlapping document asks into one list gated on a signed engagement letter.
+
+None of those corrections are visible from the template. Every one of them is the difference between a page a practitioner nods at and a page a practitioner closes. A template stamped a dozen times gets none of them, in any vertical, because the template has no opinion about the e-file rules or who requests predecessor records. Only someone standing at the altitude of the actual work knows the order is wrong.
+
+## Why the critic has to be specific, and why it runs one at a time
+
+The mechanism that produced those corrections is not general review. A generic editor pass smooths grammar and catches marketing language, which is useful and insufficient. What surfaced the authorization ordering was a critic instructed to read as a specific, skeptical practitioner: a partner who has run thousands of these engagements and is looking for the tell that the author has not. The role-play is load-bearing. A skeptical accountant and a skeptical litigator flag different things, and a critic asked to be both at once is neither.
+
+That is also why the work does not parallelize the way the UI build did. The parallel sweep worked because a frozen abstraction made the surfaces disjoint and cheap, so more agents meant more wall-clock progress. Here the scarce resource is not agent count. It is holding one industry's operational reality in focus long enough to draft it, attack it as that industry's veteran, and repair it. Split that attention across a dozen domains at once and the critiques regress to the generic mean, which is precisely the shallow template the exercise exists to escape. Depth is a serial act. The loop tightens on one vertical, closes, and moves to the next, carrying only the grammar forward, never the substance.
+
+## The transferable lesson
+
+When an agent produces many parallel artifacts that each have to be credible to a domain expert - per-vertical pages, per-tenant runbooks, per-client configurations, industry-specific docs - a template is the wrong unit of quality even when it is the right unit of structure. The template gives every artifact the same shape, and consistency of shape reads as competence only to a reader who does not know the domain. The reader who does know it is checking the substance the template cannot hold, and a stamped page fails that check identically across every instance. Depth at altitude comes from serial authoring through an adversarial loop: draft, critique in the voice of the specific practitioner who would catch the tell, rewrite, and only then move on. Reserve parallelism for work whose value lives in a shared frozen seam. Reserve serial adversarial authoring for work whose value lives in the part no template carries. Consistency you can stamp. Credibility you have to earn one at a time.
+
+---
+
+_These vertical pages were rebuilt over one continuous push across an evening and the following day, one industry at a time, each through a draft-critique-rewrite loop with the critique role-played as a skeptical practitioner from that field. The corrections described in the accounting walk are real and recorded in the page source; the lifecycle steps are framed on the pages themselves as illustrative of the shape of the work, not a fixed script, and each pairs with a fail-closed note that the agent surfaces what it found and asks where accuracy is not yet proven._

--- a/src/content/articles/exposure-vs-initiation-entitlements.md
+++ b/src/content/articles/exposure-vs-initiation-entitlements.md
@@ -1,0 +1,78 @@
+---
+title: 'What an Agent May Do Is Not How It May Start'
+date: 2026-07-01
+description: 'One authorization setting was answering two unrelated questions. Splitting exposure from initiation is what made the entitlement model enforceable.'
+author: 'Venture Crane'
+tags: ['security', 'agents', 'architecture', 'configuration', 'ai-employee']
+draft: true
+---
+
+A single setting in our AI employee product had been answering two questions that have nothing to do with each other. One question is what class of action the agent is allowed to send into the world, and how far. The other is how a given piece of work is allowed to begin. For a while both of those lived inside one scalar knob per skill, plus a scatter of per-action, per-scope, and per-mailbox overrides. It looked like one authorization model. It was two, badly interleaved, and the interleaving is what kept it from being enforceable.
+
+The product is a per-customer agent configured by a YAML file: which personas exist, which skills are enabled, what each is entitled to do. Entitlements are the part that has to be exactly right, because they are the boundary between an agent that drafts a reply for a human to send and an agent that sends it. The rebuild described here retired the old knobs entirely and replaced them with two independent axes. The general lesson is the one worth carrying off: an authorization model rots the moment one setting is asked to answer two questions.
+
+## The conflated knob
+
+The original model expressed authority as a ceiling attached to a skill. A skill had a `trust_ceiling`. Skills could carry `action_ceilings`. Scopes had their own `scope.trust_ceiling` and `scope.action_ceilings`. Managed mailboxes carried `action_ceilings` too, and provisioning had a `skill_trust_ceiling` on top of all of it. Any one of those fields, read in isolation, looked reasonable. Read together, they were four or five places that could each raise or lower what an agent was permitted to do, with no single artifact you could point at and say "this is what this persona may send."
+
+Worse, the ceiling was trying to encode two facts at once. "This skill runs autonomously" was being used to mean both "this skill may take autonomous action in the world" and, implicitly, "this skill may fire on its own." Those are different properties. A skill that triages an inbox might be allowed to run on a schedule without a human present, yet only ever be entitled to draft, never to send. A skill that sends external mail might be highly restricted in how it starts but, once a human starts it, allowed to commit. A scalar ceiling cannot represent that. It collapses two axes onto one number, and any model that collapses two independent variables into one is going to be wrong for every case where the two variables disagree.
+
+The practical symptom was that the model was not enforceable as a flag-day runtime contract. You could not take a persona's configuration and mechanically decide, at the moment an action was about to leave the system, whether it was allowed. Too much depended on which of the overlapping ceilings won.
+
+## Exposure is a property of the persona
+
+The first axis is exposure: what class of action may reach the world, and at what ceiling. Exposure is declared on the persona, not the skill, because it is a property of the identity the agent is acting as, not of any one task it performs.
+
+```yaml
+personas:
+  - slug: marcus
+    entitlements:
+      exposure:
+        internal_write: autonomous
+        external_send: draft_for_review
+    skills:
+      - name: inbox-triage
+        enabled: true
+        initiation:
+          manual: true
+          scheduled: false
+          webhook: true
+```
+
+Two design choices in that block carry the whole safety argument. First, `exposure` is sparse. It lists only the action classes that have been deliberately configured. `internal_write` and `external_send` appear here; anything not listed is simply absent. Second, and this is the load-bearing part, a missing action class fails closed at runtime and renders as unconfigured in the UI. If a persona has no entry for a given class of outbound action, the agent cannot take that action. Not "defaults to a safe ceiling" - has no entitlement at all, and the enforcement layer refuses it.
+
+`read` is the one exception, and it is an exception by omission. Reads are never customer-authored. Enforcement always allows them, so there is no `read` line for anyone to get wrong. The only things a human writes into exposure are the classes that can actually change something outside the system.
+
+## Initiation is a property of the skill
+
+The second axis is initiation: how an enabled skill is allowed to start. This one genuinely belongs to the skill, because "may this run on a cron" and "may a webhook trigger this" are facts about the task, not about the identity. Every enabled skill declares three booleans:
+
+- `initiation.manual` - a person may start it on demand
+- `initiation.scheduled` - a cron entry may start it
+- `initiation.webhook` - an inbound event may start it
+
+The enforcement rule is mechanical and reads straight off the config. A cron entry is only honored if the target skill has `scheduled: true`. A webhook trigger is only honored if the skill has `webhook: true`. An on-demand surface only appears if `manual: true`. There is no ceiling to reconcile and no inheritance to trace. The question "can this event start this skill" has exactly one place to look.
+
+Separating the two axes is what makes each one legible. Exposure answers "if this runs, what may it do to the world." Initiation answers "what is allowed to make this run." Neither can quietly stand in for the other, because they no longer share a field.
+
+## Fail-closed on the sparse case is the safety property
+
+It is worth being precise about why the sparse-plus-fail-closed design is the safety property and not just a tidiness preference. The dangerous state for an authorization model is the unconfigured one: the action class nobody thought about, the persona that was set up before that class existed, the migration that half-populated a record. A model that fills those gaps with a default is making a decision on the operator's behalf at exactly the point where the operator expressed no intent. If the default leans permissive, the gap is a hole. If it leans restrictive, you have hidden a real capability behind an invisible default and someone will "fix" it by loosening the wrong thing.
+
+Sparse exposure refuses to guess. An unconfigured action class is not a permissive default and not a silent restrictive default. It is visibly unconfigured in the UI and hard-denied at runtime. The absence of a decision is treated as the absence of authority, which is the only reading that is safe when you do not know why the field is empty. This is the same instinct as a schema that fails closed on fields it does not understand: the system that treats an absent rule as "deny" is the system that does not turn a data gap into an exposure.
+
+Two floors sit underneath all of this and do not move. Vertical compliance floors may only narrow exposure, never widen it, so an industry's boundary cannot be raised by a persona edit. And current-turn approval floors for `commitment` and `destructive` actions remain hard runtime floors regardless of exposure. Exposure decides how far a persona may generally go; these floors are the lines that a per-customer setting is not allowed to cross at all.
+
+## Breaking cleanly, with no shim
+
+The rebuild retired `trust_ceiling`, `action_ceilings`, `scope.trust_ceiling`, `scope.action_ceilings`, the mailbox-level `action_ceilings`, and provisioning's `skill_trust_ceiling`, with no compatibility shim. Validators now reject those names as legacy entitlement fields. A config written against the old model does not degrade or get silently reinterpreted; it fails validation and has to be rewritten against the two-axis model.
+
+That refusal to bridge is deliberate. A compatibility shim on an authorization model is a translation layer that has to decide what an old ceiling "meant" in the new world, which reintroduces exactly the guessing the new model was built to eliminate. When the field in question is the boundary between drafting and sending, a wrong guess during translation is not a cosmetic bug. The safer move is a hard cutover: reject the legacy shape, force each config to be re-expressed as explicit exposure and explicit initiation, and let the validator be the thing that guarantees no half-translated authority survives.
+
+## The transferable lesson
+
+When one setting answers two questions, it will be wrong for every case where the two answers disagree, and you will not be able to enforce it mechanically because enforcement requires knowing which question you are answering. The fix is not a better default or a smarter ceiling. It is to find the second question hiding inside the first and give it its own axis. Here that meant separating what a persona may expose to the world from how a skill may be started, making exposure sparse so that an unconfigured action class fails closed instead of defaulting into a decision nobody made, and cutting the legacy fields off at the validator rather than translating them. Any authorization model is a set of independent questions; the failures come from pretending two of them are one.
+
+---
+
+_This is a config-model rebuild shipped end to end: the two-axis entitlement schema, the sparse fail-closed exposure enforcement, per-skill initiation, and the validator rejection of the retired ceiling fields are built and in use. The governance audit vocabulary is now `entitlement_exposure`, `entitlement_initiation`, and `skill_enabled`. One thing the split leaves open by design: a future promotion surface must promote exposure or initiation explicitly, because with the scalar ceiling gone there is no longer a single number to raise._


### PR DESCRIPTION
Four articles from the late-June AI-employee sprint, surfaced by `/content-scan` (the window that shipped after both content streams stopped at 06-23). All land as `draft: true` — nothing goes live on merge. Publishing is a staggered draft-flip afterward (see schedule).

## Articles (all `draft: true`)

| Slug | Source | Rating |
| --- | --- | --- |
| `access-control-shared-ai-employee` | ADR 0057 — grant table is the kill switch | HIGH |
| `exposure-vs-initiation-entitlements` | ADR 0056 — two-axis entitlement model | HIGH |
| `author-built-mcp-connectors` | ADR 0053 — baked, inert until bound | MED |
| `depth-at-altitude-adversarial-authoring` | vertical-pack content depth | MED |

Each was hand-authored against the real source (ADRs / pack pages), genericized for the stealth product (no client/vendor/venture names), and run through the real `/edit-article` skill — 2 editors per article, **zero blocking findings**; Fact Checkers verified claims against live code (`grant-store.ts`, migrations, `operator/connectors/`). vc-web build passes (239 pages).

## Staggered publish (schema forbids future dates, so date is stamped at flip)

The only publish gate is `draft`; there is no date-gate. To stagger, flip one article's `draft: false` and set its `date:` to that day:

| Publish day | Article |
| --- | --- |
| Day 1 | access-control-shared-ai-employee |
| Day 2 (+2d) | exposure-vs-initiation-entitlements |
| Day 3 (+2d) | author-built-mcp-connectors |
| Day 4 (+2d) | depth-at-altitude-adversarial-authoring |

## Follow-ups discovered (NOT touched here — both are edits to already-published articles)

1. **`trust_ceiling` drift** — `agent-cant-rewrite-its-own-gate` and `live-reconfiguration-without-restart` (both live) describe `trust_ceiling` as the current model; ADR 0056 retired it. Needs a stealth-safe editorial note.
2. **law-vertical connector contradiction** — `templating-ai-service-across-verticals:34` claims the law pack "needs no custom connector," which ADR 0053 contradicts. Needs a stealth-safe correction (the obvious fix names the vendor — must be genericized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
