### PR TITLE
publish: remaining 3 sprint articles (staggered dates)

### DIFF
--- a/src/content/articles/author-built-mcp-connectors.md
+++ b/src/content/articles/author-built-mcp-connectors.md
@@ -1,10 +1,10 @@
 ---
 title: 'Bake Every Author-Built Connector In, Keep It Inert Until Bound'
-date: 2026-07-01
+date: 2026-06-29
 description: 'When a vendor has no MCP server you author your own. The real decision is where that connector code lives: baked into one shared image, inert until bound.'
 author: 'Venture Crane'
 tags: ['architecture', 'mcp', 'agents', 'ai-employee']
-draft: true
+draft: false
 ---
 
 We build an AI employee: an autonomous agent that does the connective front-desk work of a small business, and to do that job it has to bind to whatever systems of record its industry runs on. Most of those systems now expose a Model Context Protocol server, first-party or from a vetted community. You bind it as config, the agent's tools light up, and no code of yours ships to make that happen. Then you hit a vendor with no MCP server at all. The capability is real, the agent has to call it, and nobody has written the wrapper, so you write it yourself. That surfaces a question the connector strategy did not answer: where does the connector code you author physically live, and how does it reach only the machines that need it?

--- a/src/content/articles/depth-at-altitude-adversarial-authoring.md
+++ b/src/content/articles/depth-at-altitude-adversarial-authoring.md
@@ -1,10 +1,10 @@
 ---
 title: 'Template Gives You Consistency, Not Credibility'
-date: 2026-07-01
+date: 2026-06-28
 description: 'Per-vertical content a practitioner respects cannot be stamped from one template. Depth at altitude takes serial authoring through an adversarial critique loop.'
 author: 'Venture Crane'
 tags: ['content', 'methodology', 'agent-operations']
-draft: true
+draft: false
 ---
 
 A dozen vertical marketing pages for a productized AI service started as one template stamped a dozen times. Each page had the same sections, the same rhythm, the same reassuring verbs, and a different industry's nouns dropped into the slots. They were consistent. They were also generic, and generic is the one thing a domain practitioner detects on sight. So they were rebuilt, one industry at a time, each rewritten from template copy to the actual operational lifecycle of that industry, through an adversarial loop: draft, critique the draft as a skeptical practitioner from that field, rewrite against the critique. This is the account of why that work could not be batch-generated, and why doing it serially beat doing it fast.

--- a/src/content/articles/exposure-vs-initiation-entitlements.md
+++ b/src/content/articles/exposure-vs-initiation-entitlements.md
@@ -1,10 +1,10 @@
 ---
 title: 'What an Agent May Do Is Not How It May Start'
-date: 2026-07-01
+date: 2026-06-30
 description: 'One authorization setting was answering two unrelated questions. Splitting exposure from initiation is what made the entitlement model enforceable.'
 author: 'Venture Crane'
 tags: ['security', 'agents', 'architecture', 'configuration', 'ai-employee']
-draft: true
+draft: false
 ---
 
 A single setting in our AI employee product had been answering two questions that have nothing to do with each other. One question is what class of action the agent is allowed to send into the world, and how far. The other is how a given piece of work is allowed to begin. For a while both of those lived inside one scalar knob per skill, plus a scatter of per-action, per-scope, and per-mailbox overrides. It looked like one authorization model. It was two, badly interleaved, and the interleaving is what kept it from being enforceable.


### PR DESCRIPTION
Publishes the other three sprint articles with staggered dates: exposure-vs-initiation (06-30), author-built-mcp-connectors (06-29), depth-at-altitude (06-28). Content already reviewed in #158 (zero blocking). Build passes, 244 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)