### PR TITLE
fix: restore contact-form sender to contact@venturecrane.com

### DIFF
--- a/functions/api/contact.ts
+++ b/functions/api/contact.ts
@@ -13,7 +13,7 @@ interface ContactPayload {
 
 const ALLOWED_ORIGINS = ['https://venturecrane.com', 'https://www.venturecrane.com']
 const TO_EMAIL = 'smdurgan@venturecrane.com'
-const FROM_EMAIL = 'Venture Crane <contact@smd.services>'
+const FROM_EMAIL = 'Venture Crane <contact@venturecrane.com>'
 const CONTROL_CHAR_RE = /[\r\n\0]/
 
 function hasControlChars(value: string): boolean {


### PR DESCRIPTION
## What
Restores `functions/api/contact.ts` FROM to `contact@venturecrane.com`, reverting the sender change from #161.

## Why — #161 broke the production contact form
Verified against the live Resend account: vc-web's `RESEND_API_KEY` authenticates to a **different Resend account** than the one that owns `smd.services`. Sending from `contact@smd.services` therefore fails, and the live form began returning **HTTP 500**.

Evidence:
- Test POST to `venturecrane.com/api/contact` after #161 deployed → HTTP 500, and **no send record appeared** on the smd.services-owning Resend account.
- That account's only API key shows "last used 6 days ago" — the failed sends never touched it.
- `venturecrane.com` IS verified on vc-web's account (a real submission delivered on 2026-03-23), so restoring it fixes the form.

## Kept intentionally
The js-yaml + brace-expansion audit-gate `overrides` from #161 stay — they are unrelated to the sender and unblocked the frozen `npm audit` CI gate.

## Follow-up
The Resend free-tier consolidation needs re-scoping around the real multi-account topology (issue to follow); it was moved prematurely on a single-account assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)