### PR TITLE
fix: contact success message says "We'll" instead of "I'll"

### DIFF
--- a/public/js/contact.js
+++ b/public/js/contact.js
@@ -63,7 +63,7 @@ async function submitContact(e, form) {
 
     if (res.ok) {
       status.innerHTML =
-        '<div class="mb-6 rounded border border-accent/30 bg-accent/10 px-4 py-3 text-sm text-accent">Message sent. I\'ll get back to you soon.</div>'
+        '<div class="mb-6 rounded border border-accent/30 bg-accent/10 px-4 py-3 text-sm text-accent">Message sent. We\'ll get back to you soon.</div>'
       form.reset()
       form.style.display = 'none'
     } else {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -16,7 +16,7 @@ const error = Astro.url.searchParams.get('error')
       {
         sent && (
           <div class="mb-6 rounded border border-accent/30 bg-accent/10 px-4 py-3 text-sm text-accent">
-            Message sent. I'll get back to you soon.
+            Message sent. We'll get back to you soon.
           </div>
         )
       }


### PR DESCRIPTION
Copy change per the Captain: success status now reads "Message sent. We'll get back to you soon." Updated in contact.js (live path) and contact.astro's sent block (dead code in static output, kept consistent — see #164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6VRha3rjDiQZ1JwAQbneK